### PR TITLE
Don't lock python packages black version in dev-py36.txt

### DIFF
--- a/requirements/dev-py36.txt
+++ b/requirements/dev-py36.txt
@@ -4,7 +4,7 @@ aiohttp==4.0.0a1
 appdirs==1.4.3
 async-timeout==3.0.1
 attrs==19.1.0
-black==19.10b0
+black
 cachetools==4.1.0
 cffi==1.14.0
 cfgv==3.1.0


### PR DESCRIPTION
Reason:
1. Fix issue #26 Dependabot doesn't install the pre-versions of the package.
2. black is a python code formatter package, I think no specific version is OK.
3. black only has pre-release versions.