### PR TITLE
Separate the linter and test check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,35 +1,3 @@
-[tool.black]
-py36 = true
-line-length = 88
-skip-string-normalization = true
-include = '\.pyi?$'
-exclude = '''
-(
-  /(
-      \.eggs         # exclude a few common directories in the
-    | \.git          # root of the project
-    | build
-    | dist
-  )
-)
-'''
-
-# https://github.com/pytest-dev/pytest/issues/1556
-# https://github.com/pytest-dev/pytest/pull/3686
-# [tool.poetry.plugins.pytest]
-# addopts = --verbose
-# testpaths = tests
-# qt_api = pyqt5
-
-# https://gitlab.com/pycqa/flake8/issues/428
-# https://gitlab.com/pycqa/flake8/merge_requests/245
-# [tool.flake8]
-# max-line-length = 80
-
-# https://github.com/timothycrosley/isort/issues/760
-# [tool.isort]
-# line_length = 80
-# multi_line_output = 3
-# include_trailing_comma = true
-# sections = "FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER"
-# default_section = "FIRSTPARTY"
+[tool.pytest.ini_options]
+flake8-ignore = ['*.py']
+isort_ignore = ['*.py']


### PR DESCRIPTION
## Summary

Separate the linter and the test check due to the following reason
- We processed another `flake8` check in the GitHub Action workflow
- The have issues from `pytest-flake8` https://github.com/tholo/pytest-flake8/issues/87
- The community between `flake8` and `pytest` might not fix this short-term https://github.com/PyCQA/flake8/issues/1652