### PR TITLE
run script in venv through Poetry

### DIFF
--- a/.github/workflows/python-test-versions.yml
+++ b/.github/workflows/python-test-versions.yml
@@ -42,12 +42,9 @@ jobs:
         run: poetry install --no-interaction
       - name: Lint with flake8
         run: |
-          source .venv/bin/activate
           # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --exclude .venv
+          poetry run flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --exclude .venv
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --exclude .venv
+          poetry run flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --exclude .venv
       - name: Test with pytest
-        run: |
-          source .venv/bin/activate
-          pytest
+        run: poetry run pytest


### PR DESCRIPTION
I recommend  running script through Poetry after Poetry is used.

Maybe consider migrate publish action to [poetry-publish](https://github.com/marketplace/actions/publish-python-poetry-package); test action can use [actions-poetry](https://github.com/marketplace/actions/python-poetry-action)?