### PR TITLE
Remove deprecation warnings/Add support for python 3.10

### DIFF
--- a/proxybroker/api.py
+++ b/proxybroker/api.py
@@ -64,7 +64,8 @@ class Broker:
         stop_broker_on_sigint=True,
         **kwargs,
     ):
-        self._loop = loop or asyncio.get_event_loop()
+        # self._loop = loop or asyncio.get_event_loop()
+        self._loop = loop or asyncio.get_running_loop()
         self._proxies = queue or asyncio.Queue()
         self._resolver = Resolver(loop=self._loop)
         self._timeout = timeout

--- a/proxybroker/api.py
+++ b/proxybroker/api.py
@@ -64,7 +64,6 @@ class Broker:
         stop_broker_on_sigint=True,
         **kwargs,
     ):
-        # self._loop = loop or asyncio.get_event_loop()
         self._loop = loop or asyncio.get_running_loop()
         self._proxies = queue or asyncio.Queue()
         self._resolver = Resolver(loop=self._loop)

--- a/proxybroker/cli.py
+++ b/proxybroker/cli.py
@@ -385,9 +385,7 @@ def cli(args=sys.argv[1:]):
         ns.types.remove('HTTP')
         ns.types.append(('HTTP', ns.anon_lvl))
 
-    # https://github.com/pytest-dev/pytest-asyncio/issues/212#issuecomment-841992444
     loop = asyncio.get_event_loop()
-    # loop = asyncio.get_running_loop()
     proxies = asyncio.Queue()
     broker = Broker(
         proxies,
@@ -450,6 +448,3 @@ def cli(args=sys.argv[1:]):
             loop.run_forever()
     except KeyboardInterrupt:
         broker.stop()
-    finally:
-        loop.stop()
-        loop.close()

--- a/proxybroker/cli.py
+++ b/proxybroker/cli.py
@@ -363,6 +363,9 @@ async def handle(proxies, outfile, format):
             outfile.write(line)
             is_first = False
 
+async def cli_helper(tasks):
+    results = await asyncio.gather(*tasks)
+    return results
 
 def cli(args=sys.argv[1:]):
     parser = create_parser()
@@ -385,7 +388,7 @@ def cli(args=sys.argv[1:]):
         ns.types.remove('HTTP')
         ns.types.append(('HTTP', ns.anon_lvl))
 
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_event_loop_policy().get_event_loop()
     proxies = asyncio.Queue()
     broker = Broker(
         proxies,
@@ -441,7 +444,7 @@ def cli(args=sys.argv[1:]):
 
     try:
         if tasks:
-            loop.run_until_complete(asyncio.gather(*tasks))
+            loop.run_until_complete(cli_helper(tasks))
             if ns.show_stats:
                 broker.show_stats(verbose=True)
         else:

--- a/proxybroker/cli.py
+++ b/proxybroker/cli.py
@@ -363,10 +363,6 @@ async def handle(proxies, outfile, format):
             outfile.write(line)
             is_first = False
 
-async def cli_helper(tasks):
-    results = await asyncio.gather(*tasks)
-    return results
-
 def cli(args=sys.argv[1:]):
     parser = create_parser()
     ns = parser.parse_args(args)
@@ -444,7 +440,7 @@ def cli(args=sys.argv[1:]):
 
     try:
         if tasks:
-            loop.run_until_complete(cli_helper(tasks))
+            loop.run_until_complete(asyncio.gather(*tasks))
             if ns.show_stats:
                 broker.show_stats(verbose=True)
         else:

--- a/proxybroker/providers.py
+++ b/proxybroker/providers.py
@@ -607,7 +607,7 @@ class Proxyb_net(Provider):
             return []
         _hosts, _ports = page.split('","ports":"')
         hosts, ports = [], []
-        for host in _hosts.split('<\/tr><tr>'):  # noqa: W605
+        for host in _hosts.split('</tr><tr>'):  # noqa: W605
             host = IPPattern.findall(host)
             if not host:
                 continue

--- a/proxybroker/proxy.py
+++ b/proxybroker/proxy.py
@@ -43,9 +43,9 @@ class Proxy:
 
         :param str host: A passed host can be a domain or IP address.
                          If the host is a domain, try to resolve it
-        :param str \*args:
+        :param str *args:
             (optional) Positional arguments that :class:`Proxy` takes
-        :param str \*\*kwargs:
+        :param str **kwargs:
             (optional) Keyword arguments that :class:`Proxy` takes
 
         :return: :class:`Proxy` object


### PR DESCRIPTION
Result
![image](https://user-images.githubusercontent.com/50429450/186061868-34b45021-20d7-4797-8005-d61916fa72fc.png)

I'm not entirely sure how to remove the other deprecation warnings.
[DeprecationWarning: Using ioctl() method](https://github.com/python/cpython/issues/89111)
[asyncio DatagramProtocol stops calling callbacks after OSError](https://bugs.python.org/issue44743)

Related to:
#89 
