### PR TITLE
instructions to compile proxybroker to shared executable for Major platforms (Windows, Linux, and MacOS)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,13 +14,13 @@
 				"ms-python.python"
 			]
 		}
-	}
+	},
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 
 	// Uncomment the next line to run commands after the container is created - for example installing curl.
-	// "postCreateCommand": "apt-get update && apt-get install -y curl",
+	"postCreateCommand": "apt-get update && apt-get install -y binutils upx-ucl && pip install pyinstaller && pip install ."
 
 	// Uncomment when using a ptrace-based debugger like C++, Go, and Rust
 	// "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,6 +1,6 @@
 # These are supported funding model platforms
 
-github: [bluet] # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
 patreon: # Replace with a single Patreon username
 open_collective: # Replace with a single Open Collective username
 ko_fi: bluet

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,6 +1,6 @@
 # These are supported funding model platforms
 
-github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+github: [bluet] # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
 patreon: # Replace with a single Patreon username
 open_collective: # Replace with a single Open Collective username
 ko_fi: bluet

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build
 dist
 /venv
 Pipfile*
+*.spec

--- a/README.md
+++ b/README.md
@@ -100,33 +100,83 @@ The latest development version can be installed directly from GitHub:
 $ pip install -U git+https://github.com/bluet/proxybroker2.git
 ```
 
-Compiling to a dynamically linked executable
+### Build bundled one-file executable with pyinstaller
 
-Important Notes: 
-- Installs the package on your system
+#### Requirements
 
-Unix
+Unix based systems
 
-Requirements: 
-- objdump command (usually located in binutils package)
-- Upx (decreases executable size, optional)
+Install these tools
+ - upx
+ - objdump (this tool is usually in the bintools package)
 
 ```
 pip install pyinstaller \
 && pip install . \
 && mkdir -p build \
 && cd build \
-&& pyinstaller --onefile --add-data "../proxybroker/data:data" --workpath ./tmp --distpath . --clean $(which proxybroker) \
+&& pyinstaller --onefile --name proxybroker --add-data "../proxybroker/data:data" --workpath ./tmp --distpath . --clean ../py2exe_entrypoint.py \
 && rm -rf tmp
 ```
 
-The executable is now in dist/proxybroker directory
+The executable is now in the build directory
 
-Debug
-- pyi-archive_viewer ./dist/proxybroker to view the archived contents in the executable
+Windows
 
-Usage
+```
+pip install pyinstaller \
+&& pip install . \
+&& mkdir -p build \
+&& cd build \
+&& pyinstaller --onefile --name proxybroker --add-data "../proxybroker/data;data" --workpath ./tmp --distpath . --clean ../py2exe_entrypoint.py \
+&& rm -rf tmp
+```
+
+
+### Use pre-built Docker image
+``` {.sourceCode .bash}
+$ docker run --rm bluet/proxybroker2 --help
+  usage: proxybroker [--max-conn MAX_CONN] [--max-tries MAX_TRIES]
+                     [--timeout SECONDS] [--judge JUDGES] [--provider PROVIDERS]
+                     [--verify-ssl]
+                     [--log [{NOTSET,DEBUG,INFO,WARNING,ERROR,CRITICAL}]]
+                     [--min-queue MINIMUM_PROXIES_IN_QUEUE]
+                     [--version] [--help]
+                     {find,grab,serve,update-geo} ...
+
+  Proxy [Finder | Checker | Server]
+
+  Commands:
+    These are common commands used in various situations
+
+    {find,grab,serve,update-geo}
+      find                Find and check proxies
+      grab                Find proxies without a check
+      serve               Run a local proxy server
+      update-geo          Download and use a detailed GeoIP database
+
+  Options:
+    --max-conn MAX_CONN   The maximum number of concurrent checks of proxies
+    --max-tries MAX_TRIES
+                          The maximum number of attempts to check a proxy
+    --timeout SECONDS, -t SECONDS
+                          Timeout of a request in seconds. The default value is
+                          8 seconds
+    --judge JUDGES        Urls of pages that show HTTP headers and IP address
+    --provider PROVIDERS  Urls of pages where to find proxies
+    --verify-ssl, -ssl    Flag indicating whether to check the SSL certificates
+    --min-queue MINIMUM_PROXIES_IN_QUEUE   The minimum number of proxies in the queue for checking connectivity
+    --log [{NOTSET,DEBUG,INFO,WARNING,ERROR,CRITICAL}]
+                          Logging level
+    --version, -v         Show program's version number and exit
+    --help, -h            Show this help message and exit
+
+  Run 'proxybroker <command> --help' for more information on a command.
+  Suggestions and bug reports are greatly appreciated:
+  <https://github.com/bluet/proxybroker2/issues>
+
 -----
+```
 
 ### CLI Examples
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,31 @@ The latest development version can be installed directly from GitHub:
 $ pip install -U git+https://github.com/bluet/proxybroker2.git
 ```
 
+Compiling to a dynamically linked executable
+
+Important Notes: 
+- Installs the package on your system
+
+Unix
+
+Requirements: 
+- objdump command (usually located in binutils package)
+- Upx (decreases executable size, optional)
+
+```
+pip install pyinstaller \
+&& pip install . \
+&& mkdir -p build \
+&& cd build \
+&& pyinstaller --onefile --add-data "../proxybroker/data:data" --workpath ./tmp --distpath . --clean $(which proxybroker) \
+&& rm -rf tmp
+```
+
+The executable is now in dist/proxybroker directory
+
+Debug
+- pyi-archive_viewer ./dist/proxybroker to view the archived contents in the executable
+
 Usage
 -----
 

--- a/proxybroker/resolver.py
+++ b/proxybroker/resolver.py
@@ -1,9 +1,12 @@
+
 import asyncio
 import ipaddress
 import os.path
 import random
 import socket
+import sys
 from collections import namedtuple
+from importlib.util import find_spec
 
 import aiodns
 import aiohttp

--- a/proxybroker/utils.py
+++ b/proxybroker/utils.py
@@ -1,5 +1,6 @@
 """Utils."""
 
+import sys
 import logging
 import os
 import os.path
@@ -13,7 +14,7 @@ import urllib.request
 from . import __version__ as version
 from .errors import BadStatusLine
 
-BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+BASE_DIR = getattr(sys, '_MEIPASS', os.path.dirname(os.path.abspath(__file__)))
 DATA_DIR = os.path.join(BASE_DIR, 'data')
 log = logging.getLogger(__package__)
 

--- a/py2exe_entrypoint.py
+++ b/py2exe_entrypoint.py
@@ -1,0 +1,2 @@
+import proxybroker.cli as proxybroker_cli
+proxybroker_cli.cli()


### PR DESCRIPTION
Instructions for #31. 

The steps for macos should be the same.
For windows it should be very similar the end of the `$(which proxybroker)` should be replaced with the location of the proxybroker script