### PR TITLE
use setup-python built-in cache functionality

### DIFF
--- a/.github/workflows/python-test-versions.yml
+++ b/.github/workflows/python-test-versions.yml
@@ -20,24 +20,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
       - name: Install and configure Poetry
         uses: snok/install-poetry@v1.3.1
         with:
           version: ${{ matrix.poetry-version }}
           virtualenvs-in-project: true
-      - name: Load cached venv
-        id: cached-poetry-dependencies
-        uses: actions/cache@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
         with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
-      - name: Install dependencies
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: poetry install --no-interaction --no-root
+          python-version: ${{ matrix.python-version }}
+          cache: 'poetry'
       - name: Install library
         run: poetry install --no-interaction
       - name: Lint with flake8


### PR DESCRIPTION
see
https://github.com/actions/setup-python#caching-packages-dependencies

------

I read both the source code of [actions-poetry](https://github.com/marketplace/actions/python-poetry-action) and [snok/install-poetry](https://github.com/snok/install-poetry) (current use). The install-poetry action has more custom options, so I decided to improve the cache usage.

As [my comment](https://github.com/bluet/proxybroker2/issues/93#issuecomment-1225179188) say, there are many things to do (defork, build workflow and contribution guide, etc.). I will keep helping and pushing this project :)