### PR TITLE
bump Poetry in action and remove requirements.txt

### DIFF
--- a/.github/workflows/python-test-versions.yml
+++ b/.github/workflows/python-test-versions.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10"]
-        poetry-version: ["1.1.14"]
+        poetry-version: ["1.2.2", "1.3.1"]
 
     steps:
       - uses: actions/checkout@v3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
--r requirements/base.txt


### PR DESCRIPTION
TL;DR

1. Bump Poetry version (1.1.14 -> 1.2.2 & 1.3.1) in action pipeline
2. Remove `requirements.txt`

------

In #105 , I think it is time to update Poetry. Both of 1.2 and 1.3 add many breaking but useful features (ex: lock file format 2.0). However, some device may face issue when they upgrade from 1.1. For example, my personal computer and raspberry pi 4 work fine, but device my job use failed in upgrade.

Because of those, I set two Poetry version matrix to cover 1.2 and 1.3, but drop 1.1. This mean all maintainer of this project should not use Poetry before version 1.2.

Also, I remove the `requirements.txt`, maintain `pyproject.toml` and `poetry.lock` is the only thing need to do of dependencies management.

If everyone ready, let's merge and move one step closer to the goal (release new packae)!