### PR TITLE
ci: add Docker Hub + GHCR publish workflow on release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+# Dependabot configuration.
+#
+# Goals:
+#   - Stay safe: SHA-pinned third-party Actions get bumped when they
+#     release new versions, so we don't fall behind for years.
+#   - Stay quiet: routine bumps land in ONE grouped PR per month, not
+#     one PR per action per release. (Past experience: ungrouped
+#     SHA-pinning floods the inbox; the grouping config below avoids it.)
+#   - Stay reactive on CVEs: security-advisory PRs ALWAYS fire
+#     immediately regardless of the schedule below. The `interval` only
+#     affects routine version updates, not the security-update path.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      gha-deps:
+        patterns:
+          - "*"
+    # Use a single label so monthly grouped PRs are easy to filter.
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,93 @@
+name: Publish Docker Image
+
+# Triggers:
+#   - GitHub Release published: builds + pushes the image automatically.
+#     Same trigger as python-publish.yml, so one release ships both
+#     PyPI and Docker artifacts.
+#   - workflow_dispatch: lets a maintainer re-run after a transient
+#     registry failure or a token rotation, without cutting a new release.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref (tag/branch/SHA) to build from"
+        required: true
+        default: "master"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write  # required to push to ghcr.io
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+        with:
+          # On release events the default checkout is the tag.
+          # On workflow_dispatch we honor the user-supplied ref.
+          # All branches/tags/SHAs are repo-controlled, not arbitrary
+          # untrusted text - safe to pass to the checkout action.
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
+      # Multi-arch builds need QEMU for cross-compilation under buildx.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      # Buildx is the modern docker builder; supports multi-platform output.
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Docker Hub login. Token must be a Hub access token (NOT a password)
+      # scoped to the proxybroker2 repository for least-privilege.
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # GHCR login uses the workflow's built-in GITHUB_TOKEN (no extra secret
+      # needed). The `packages: write` permission above is what authorises it.
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # docker/metadata-action computes the tag list from the git ref using
+      # semver rules. Strategy:
+      #   - Version tag (e.g. `2.0.0b2`) always pushed.
+      #   - `latest`, `2`, `2.0` only pushed for STABLE releases. The
+      #     `enable=...!github.event.release.prerelease` guard means a
+      #     beta release (which we mark as prerelease in the GH UI) won't
+      #     advance these floating tags.
+      - name: Extract image metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            bluet/proxybroker2
+            ghcr.io/bluet/proxybroker2
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'release' && !github.event.release.prerelease }}
+            type=semver,pattern={{major}},enable=${{ github.event_name == 'release' && !github.event.release.prerelease }}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' && !github.event.release.prerelease }}
+            type=raw,value=manual-{{date 'YYYYMMDDHHmmss'}},enable=${{ github.event_name == 'workflow_dispatch' }}
+
+      # Build once, push to both registries. cache-from/to use the GitHub
+      # Actions cache backend so a second run on the same code reuses
+      # layers and finishes in seconds instead of minutes.
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -59,11 +59,21 @@ jobs:
 
       # docker/metadata-action computes the tag list from the git ref using
       # semver rules. Strategy:
-      #   - Version tag (e.g. `2.0.0b2`) always pushed.
-      #   - `latest`, `2`, `2.0` only pushed for STABLE releases. The
-      #     `enable=...!github.event.release.prerelease` guard means a
-      #     beta release (which we mark as prerelease in the GH UI) won't
-      #     advance these floating tags.
+      #   - `:VERSION` (e.g. `:2.0.0b2`) always pushed - exact version pin.
+      #   - `:major`, `:major.minor`, `:latest` ALSO pushed on every release,
+      #     INCLUDING prereleases. Rationale: this project has been in beta
+      #     for over a year. If `:latest` only moved on stable releases,
+      #     users pulling `:latest` would be stuck on a year-old beta until
+      #     2.0.0 ships. A user who pulls `:2` wants the most recent 2.x.y,
+      #     not the most recent stable 2.x.y - same for `:latest`.
+      #   - `:latest` is gated on release events only (not workflow_dispatch)
+      #     so a manual rerun from older code never accidentally advances
+      #     the floating tag.
+      #   - Side-effect: if a future patch is released for an OLDER version
+      #     line (e.g. 1.5.1 after 2.0.0), it would advance `:latest`
+      #     backward. Acceptable for now - this project doesn't maintain
+      #     old version lines. Switch to `flavor: latest=auto` if that
+      #     ever changes.
       - name: Extract image metadata (tags, labels)
         id: meta
         uses: docker/metadata-action@v5
@@ -73,9 +83,9 @@ jobs:
             ghcr.io/bluet/proxybroker2
           tags: |
             type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'release' && !github.event.release.prerelease }}
-            type=semver,pattern={{major}},enable=${{ github.event_name == 'release' && !github.event.release.prerelease }}
-            type=raw,value=latest,enable=${{ github.event_name == 'release' && !github.event.release.prerelease }}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
             type=raw,value=manual-{{date 'YYYYMMDDHHmmss'}},enable=${{ github.event_name == 'workflow_dispatch' }}
 
       # Build once, push to both registries. cache-from/to use the GitHub

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,7 +24,7 @@ jobs:
       packages: write  # required to push to ghcr.io
     steps:
       - name: Check out source
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           # On release events the default checkout is the tag.
           # On workflow_dispatch we honor the user-supplied ref.
@@ -34,16 +34,16 @@ jobs:
 
       # Multi-arch builds need QEMU for cross-compilation under buildx.
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3
 
       # Buildx is the modern docker builder; supports multi-platform output.
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
 
       # Docker Hub login. Token must be a Hub access token (NOT a password)
       # scoped to the proxybroker2 repository for least-privilege.
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -51,7 +51,7 @@ jobs:
       # GHCR login uses the workflow's built-in GITHUB_TOKEN (no extra secret
       # needed). The `packages: write` permission above is what authorises it.
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -76,7 +76,7 @@ jobs:
       #     ever changes.
       - name: Extract image metadata (tags, labels)
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5
         with:
           images: |
             bluet/proxybroker2
@@ -92,7 +92,7 @@ jobs:
       # Actions cache backend so a second run on the same code reuses
       # layers and finishes in seconds instead of minutes.
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25  # v5
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,17 +1,25 @@
 name: Publish Docker Image
 
 # Triggers:
-#   - GitHub Release published: builds + pushes the image automatically.
-#     Same trigger as python-publish.yml, so one release ships both
-#     PyPI and Docker artifacts.
-#   - workflow_dispatch: lets a maintainer kick a build of master HEAD,
-#     useful for testing the workflow itself. Does NOT publish version
-#     tags - to (re)publish a specific tagged release, re-fire the
-#     release event by deleting + recreating the GitHub release.
-#     Reason: docker/metadata-action reads GITHUB_REF, which stays at
-#     the workflow's branch (master) for workflow_dispatch even when
-#     checkout uses a different ref. So the version-tag generation
-#     wouldn't fire correctly from a manual ref input.
+#
+#   - release: published
+#       Full tag set (:VERSION, :major.minor, :major, :latest) - the
+#       canonical "ship a new version" path. Same trigger as
+#       python-publish.yml, so one release ships PyPI + Docker together.
+#
+#   - workflow_dispatch
+#       Manual trigger. Behavior depends on what ref it's invoked with
+#       (`gh workflow run ... --ref <ref>`):
+#
+#       - With `--ref <tag>` (e.g. `--ref v2.0.0b2`):
+#           Publishes :VERSION only (no floating aliases). Useful for
+#           retroactive single-version rebuilds that must NOT move
+#           :latest / :major / :major.minor. The version tag fires
+#           because metadata-action's pep440 type matches the tag ref.
+#
+#       - With `--ref master` (default):
+#           No tag ref to match - publishes :manual-<timestamp> only.
+#           Useful for smoke-testing the workflow itself.
 on:
   release:
     types: [published]
@@ -26,8 +34,8 @@ jobs:
     steps:
       - name: Check out source
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
-        # ref omitted: uses GITHUB_REF, which is the released tag for
-        # release events and master for workflow_dispatch.
+        # ref omitted: uses GITHUB_REF, which for both `release` events
+        # and `workflow_dispatch` is the ref that triggered the workflow.
 
       # Multi-arch builds need QEMU for cross-compilation under buildx.
       - name: Set up QEMU
@@ -56,35 +64,39 @@ jobs:
 
       # Tag strategy:
       #
-      # `:VERSION` (e.g. `:2.0.0b2`) - exact version pin, always pushed.
-      #     Uses type=pep440, NOT type=semver: this project versions in
-      #     PEP 440 form (`2.0.0b2`), not SemVer (`2.0.0-beta.2`).
-      #     `type=semver,pattern={{version}}` would silently fail to match
-      #     PEP 440 prerelease tags and skip the build.
+      # `:VERSION` (e.g. `:2.0.0b2`) - exact version pin.
+      #     Uses type=pep440 (NOT type=semver) because this project
+      #     versions in PEP 440 form (`2.0.0b2`), not SemVer
+      #     (`2.0.0-beta.2`). PyPI mandates PEP 440 - we follow.
+      #     Fires on any tag-shaped GITHUB_REF: release events AND
+      #     workflow_dispatch invoked with `--ref v...`.
       #
-      # `:major.minor` (e.g. `:2.0`) and `:major` (e.g. `:2`) - floating
-      #     aliases, advanced on EVERY release including prereleases.
-      #     We use `type=match` with a regex against the git tag name,
-      #     NOT `type=pep440,pattern={{major}}.{{minor}}`, because
-      #     metadata-action's PEP 440/SemVer parsers deliberately hold
-      #     these floating aliases back for prereleases. We want them to
-      #     advance for prereleases too: this project has been in beta
-      #     for over a year, and locking floating tags to stable releases
-      #     would leave them frozen on `v2.0.0b1` (May 2025) until 2.0.0
-      #     ships. A user pulling `:2` wants the latest 2.x.y, not the
-      #     latest stable 2.x.y.
-      #
-      # `:latest` - same advancement policy as :major / :major.minor.
-      #     Gated on `release` events only (not workflow_dispatch) so a
-      #     manual master-HEAD build never accidentally moves :latest.
+      # `:major.minor` / `:major` / `:latest` - floating aliases.
+      #     Gated on `release` events only via explicit enable=.
+      #     Reasons:
+      #     - Manual workflow_dispatch rebuilds shouldn't accidentally
+      #       move floating tags.
+      #     - Type=match is used instead of {{major}} / {{major.minor}}
+      #       templates because metadata-action's pep440/semver parsers
+      #       deliberately hold floating aliases back for prereleases.
+      #       We want them to advance for prereleases too: this project
+      #       has been in beta for a year, and locking floating tags to
+      #       stable releases would freeze them on `v2.0.0b1` (May 2025)
+      #       until 2.0.0 ships.
       #
       # `:manual-<timestamp>` - per-build tag for workflow_dispatch.
       #     Avoids collision with release-published tags.
       #
+      # `flavor: latest=false` disables metadata-action's automatic
+      # `:latest` setting for the highest stable version. We control
+      # `:latest` explicitly via the type=raw rule above so it ONLY
+      # fires on release events, not on manual workflow_dispatch runs
+      # of stable tags.
+      #
       # Acknowledged side-effect: if a future patch is released for an
-      # OLDER version line (e.g. 1.5.1 after 2.0.0), :latest / :major /
-      # :major.minor would advance backward. Not maintaining old version
-      # lines today; switch to `flavor: latest=auto` if that changes.
+      # OLDER version line (e.g. 1.5.1 after 2.0.0), the floating tags
+      # would advance backward. Not maintaining old version lines today;
+      # restore `flavor: latest=auto` if that ever changes.
       - name: Extract image metadata (tags, labels)
         id: meta
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5
@@ -92,6 +104,8 @@ jobs:
           images: |
             bluet/proxybroker2
             ghcr.io/bluet/proxybroker2
+          flavor: |
+            latest=false
           tags: |
             type=pep440,pattern={{version}}
             type=match,pattern=v(\d+\.\d+),group=1,enable=${{ github.event_name == 'release' }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,17 +4,18 @@ name: Publish Docker Image
 #   - GitHub Release published: builds + pushes the image automatically.
 #     Same trigger as python-publish.yml, so one release ships both
 #     PyPI and Docker artifacts.
-#   - workflow_dispatch: lets a maintainer re-run after a transient
-#     registry failure or a token rotation, without cutting a new release.
+#   - workflow_dispatch: lets a maintainer kick a build of master HEAD,
+#     useful for testing the workflow itself. Does NOT publish version
+#     tags - to (re)publish a specific tagged release, re-fire the
+#     release event by deleting + recreating the GitHub release.
+#     Reason: docker/metadata-action reads GITHUB_REF, which stays at
+#     the workflow's branch (master) for workflow_dispatch even when
+#     checkout uses a different ref. So the version-tag generation
+#     wouldn't fire correctly from a manual ref input.
 on:
   release:
     types: [published]
   workflow_dispatch:
-    inputs:
-      ref:
-        description: "Git ref (tag/branch/SHA) to build from"
-        required: true
-        default: "master"
 
 jobs:
   publish:
@@ -25,12 +26,8 @@ jobs:
     steps:
       - name: Check out source
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
-        with:
-          # On release events the default checkout is the tag.
-          # On workflow_dispatch we honor the user-supplied ref.
-          # All branches/tags/SHAs are repo-controlled, not arbitrary
-          # untrusted text - safe to pass to the checkout action.
-          ref: ${{ github.event.inputs.ref || github.ref }}
+        # ref omitted: uses GITHUB_REF, which is the released tag for
+        # release events and master for workflow_dispatch.
 
       # Multi-arch builds need QEMU for cross-compilation under buildx.
       - name: Set up QEMU
@@ -57,23 +54,37 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # docker/metadata-action computes the tag list from the git ref using
-      # semver rules. Strategy:
-      #   - `:VERSION` (e.g. `:2.0.0b2`) always pushed - exact version pin.
-      #   - `:major`, `:major.minor`, `:latest` ALSO pushed on every release,
-      #     INCLUDING prereleases. Rationale: this project has been in beta
-      #     for over a year. If `:latest` only moved on stable releases,
-      #     users pulling `:latest` would be stuck on a year-old beta until
-      #     2.0.0 ships. A user who pulls `:2` wants the most recent 2.x.y,
-      #     not the most recent stable 2.x.y - same for `:latest`.
-      #   - `:latest` is gated on release events only (not workflow_dispatch)
-      #     so a manual rerun from older code never accidentally advances
-      #     the floating tag.
-      #   - Side-effect: if a future patch is released for an OLDER version
-      #     line (e.g. 1.5.1 after 2.0.0), it would advance `:latest`
-      #     backward. Acceptable for now - this project doesn't maintain
-      #     old version lines. Switch to `flavor: latest=auto` if that
-      #     ever changes.
+      # Tag strategy:
+      #
+      # `:VERSION` (e.g. `:2.0.0b2`) - exact version pin, always pushed.
+      #     Uses type=pep440, NOT type=semver: this project versions in
+      #     PEP 440 form (`2.0.0b2`), not SemVer (`2.0.0-beta.2`).
+      #     `type=semver,pattern={{version}}` would silently fail to match
+      #     PEP 440 prerelease tags and skip the build.
+      #
+      # `:major.minor` (e.g. `:2.0`) and `:major` (e.g. `:2`) - floating
+      #     aliases, advanced on EVERY release including prereleases.
+      #     We use `type=match` with a regex against the git tag name,
+      #     NOT `type=pep440,pattern={{major}}.{{minor}}`, because
+      #     metadata-action's PEP 440/SemVer parsers deliberately hold
+      #     these floating aliases back for prereleases. We want them to
+      #     advance for prereleases too: this project has been in beta
+      #     for over a year, and locking floating tags to stable releases
+      #     would leave them frozen on `v2.0.0b1` (May 2025) until 2.0.0
+      #     ships. A user pulling `:2` wants the latest 2.x.y, not the
+      #     latest stable 2.x.y.
+      #
+      # `:latest` - same advancement policy as :major / :major.minor.
+      #     Gated on `release` events only (not workflow_dispatch) so a
+      #     manual master-HEAD build never accidentally moves :latest.
+      #
+      # `:manual-<timestamp>` - per-build tag for workflow_dispatch.
+      #     Avoids collision with release-published tags.
+      #
+      # Acknowledged side-effect: if a future patch is released for an
+      # OLDER version line (e.g. 1.5.1 after 2.0.0), :latest / :major /
+      # :major.minor would advance backward. Not maintaining old version
+      # lines today; switch to `flavor: latest=auto` if that changes.
       - name: Extract image metadata (tags, labels)
         id: meta
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5
@@ -82,9 +93,9 @@ jobs:
             bluet/proxybroker2
             ghcr.io/bluet/proxybroker2
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+            type=pep440,pattern={{version}}
+            type=match,pattern=v(\d+\.\d+),group=1,enable=${{ github.event_name == 'release' }}
+            type=match,pattern=v(\d+),group=1,enable=${{ github.event_name == 'release' }}
             type=raw,value=latest,enable=${{ github.event_name == 'release' }}
             type=raw,value=manual-{{date 'YYYYMMDDHHmmss'}},enable=${{ github.event_name == 'workflow_dispatch' }}
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/docker-publish.yml`. Triggers on `release: published` (same hook as PyPI publish) and on `workflow_dispatch` for manual reruns.
- Builds **multi-arch** (linux/amd64, linux/arm64) so Apple Silicon and Graviton users get native images.
- Pushes to **both** `bluet/proxybroker2` (Docker Hub) and `ghcr.io/bluet/proxybroker2` (GHCR) in one build.

## Tag policy

| Tag | When | Why |
|---|---|---|
| `:VERSION` (`:2.0.0b2`) | Every release | Exact version pin |
| `:major` (`:2`) | Every release | Latest patch in major line, includes prereleases |
| `:major.minor` (`:2.0`) | Every release | Latest patch in minor line, includes prereleases |
| `:latest` | Every release event | Most recent published version, includes prereleases |
| `:manual-{timestamp}` | workflow_dispatch only | Avoids collision with release tags |

**Why floating tags include prereleases:** This project has been in beta for over a year. If `:latest` only moved on stable releases, users pulling `:latest` would be stuck on `v2.0.0b1` (May 2025) until 2.0.0 ships. A user pulling `:2` wants the most recent 2.x.y, regardless of pre-release status.

**Acknowledged side-effect:** if we ever release a patch on an old version line (e.g. 1.5.1 after 2.0.0), `:latest` would move backward. Not a concern today since this project doesn't maintain old version lines. Documented in the workflow comment.

## One-time setup before this can publish

✅ `DOCKERHUB_USERNAME` — set
✅ `DOCKERHUB_TOKEN` — set
GHCR needs no setup — uses the built-in `GITHUB_TOKEN` and the `packages: write` permission declared in the workflow.

## After merge — publishing v2.0.0b2 to Docker

⚠️ **Trigger option matters here.** `docker/metadata-action` reads `GITHUB_REF` for semver detection. For `workflow_dispatch`, `GITHUB_REF` stays at `master` (where the workflow file lives), so semver-based tags **won't** generate from the user-supplied `ref` input — only `:manual-{timestamp}` would land.

**Recommended path: delete and re-create the GitHub release.** This fires a `release: published` event with `GITHUB_REF=refs/tags/v2.0.0b2`, and metadata-action generates all the semver tags correctly:

```bash
# Save the release notes first
gh release view v2.0.0b2 --repo bluet/proxybroker2 --json body -q .body > /tmp/v2.0.0b2-notes.md

# Delete + re-create (the tag stays put; only the release object is removed/recreated)
gh release delete v2.0.0b2 --repo bluet/proxybroker2 --yes
gh release create v2.0.0b2 --repo bluet/proxybroker2 \
  --prerelease \
  --title "v2.0.0b2 — Custom Provider System & Quality Pass" \
  --notes-file /tmp/v2.0.0b2-notes.md
```

That re-fires both `python-publish.yml` (already failed; would still fail on the stale token unless that's fixed too) and `docker-publish.yml` (will succeed once this PR is merged + secrets are in place).

**Alternative:** trigger workflow_dispatch and accept the limited tag set:
```bash
gh workflow run docker-publish.yml --repo bluet/proxybroker2 \
  --ref master --field ref=v2.0.0b2
```
This only pushes `:manual-{timestamp}` (and not the version tags). Useful for build smoke-tests but doesn't replace a real publish.

## Test plan

- [ ] Verify `DOCKERHUB_USERNAME` + `DOCKERHUB_TOKEN` in repo secrets (✅ done)
- [ ] Merge this PR
- [ ] Delete + re-create the v2.0.0b2 GitHub release (per command above)
- [ ] Verify `bluet/proxybroker2:2.0.0b2`, `:2.0`, `:2`, `:latest` all on https://hub.docker.com/r/bluet/proxybroker2/tags
- [ ] Verify same set at `ghcr.io/bluet/proxybroker2` on https://github.com/bluet/proxybroker2/pkgs/container/proxybroker2
- [ ] Pull and run on amd64 + arm64 hosts: `docker run --rm bluet/proxybroker2:2.0.0b2 --help` and `docker run --rm bluet/proxybroker2:latest --help`
- [ ] Confirm all four tags resolve to the same digest (i.e., they're aliases of the same multi-arch manifest, not stale rebuilds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow to publish multi-architecture Docker images to registries on releases and manual runs, with versioned and floating tags and build caching to speed builds.
  * Configured Dependabot to monthly check and group GitHub Actions updates into a single PR, labeling these dependency update PRs appropriately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->