### PR TITLE
ci: bump all actions to Node 24 + add LABEL for GHCR auth

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,7 +25,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 1
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -33,22 +33,22 @@ jobs:
       packages: write  # required to push to ghcr.io
     steps:
       - name: Check out source
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         # ref omitted: uses GITHUB_REF, which for both `release` events
         # and `workflow_dispatch` is the ref that triggered the workflow.
 
       # Multi-arch builds need QEMU for cross-compilation under buildx.
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a  # v4.0.0
 
       # Buildx is the modern docker builder; supports multi-platform output.
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
 
       # Docker Hub login. Token must be a Hub access token (NOT a password)
       # scoped to the proxybroker2 repository for least-privilege.
       - name: Log in to Docker Hub
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -56,7 +56,7 @@ jobs:
       # GHCR login uses the workflow's built-in GITHUB_TOKEN (no extra secret
       # needed). The `packages: write` permission above is what authorises it.
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -99,7 +99,7 @@ jobs:
       # restore `flavor: latest=auto` if that ever changes.
       - name: Extract image metadata (tags, labels)
         id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf  # v6.0.0
         with:
           images: |
             bluet/proxybroker2
@@ -117,7 +117,7 @@ jobs:
       # Actions cache backend so a second run on the same code reuses
       # layers and finishes in seconds instead of minutes.
       - name: Build and push
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25  # v5
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/py-to-exe.yml
+++ b/.github/workflows/py-to-exe.yml
@@ -20,13 +20,13 @@ jobs:
         python-version: ["3.14"]  # Default to current Python; revert to 3.13 if PyInstaller breaks
         poetry-version: ["2.3.2"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install and configure Poetry
-        uses: snok/install-poetry@v1.4.1
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a  # v1.4.1
         with:
           version: ${{ matrix.poetry-version }}
           virtualenvs-in-project: true
@@ -48,7 +48,7 @@ jobs:
           poetry run pyinstaller --onefile --name proxybroker-${RUNNER_OS}-$(arch) --add-data "../proxybroker/data${PATH_SEPARATOR}data" --workpath ./tmp --distpath . --clean ../py2exe_entrypoint.py;
           rm -rf tmp *.spec;
       - name: Archive proxybroker artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: proxybroker-build-artifacts-${{ matrix.os }}
           path: build/proxybroker-*-*

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -18,9 +18,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
       with:
         python-version: '3.14'
     - name: Install dependencies

--- a/.github/workflows/python-test-versions.yml
+++ b/.github/workflows/python-test-versions.yml
@@ -19,14 +19,14 @@ jobs:
         poetry-version: ["2.3.2"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Install and configure Poetry
-        uses: snok/install-poetry@v1.4.1
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a  # v1.4.1
         with:
           version: ${{ matrix.poetry-version }}
           virtualenvs-in-project: true
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'poetry'

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,14 @@
 #   docker inspect --format '{{index .RepoDigests 0}}' python:3.14-slim
 FROM python:3.14-slim@sha256:5b3879b6f3cb77e712644d50262d05a7c146b7312d784a18eff7ff5462e77033 AS base
 
+# Connects this image to its source repo on GitHub Container Registry.
+# Without this label, GHCR cannot link the package to the repo, and the
+# workflow's GITHUB_TOKEN gets a 403 Forbidden on first push to a new
+# package in the namespace - even with `permissions: packages: write`
+# set in the workflow. Per GitHub docs:
+# https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry
+LABEL org.opencontainers.image.source="https://github.com/bluet/proxybroker2"
+
 ENV \
     # Keeps Python from generating .pyc files in the container
     PYTHONDONTWRITEBYTECODE=1 \


### PR DESCRIPTION
## Summary

Two related fixes uncovered while debugging the v2.0.0b2 Docker publish:

### (a) Fix GHCR 403 Forbidden via OCI label

The recent `workflow_dispatch` test of `docker-publish.yml` revealed that the multi-arch image built fine but the **first push to ghcr.io failed with 403 Forbidden**. Per the [official GHCR docs](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry):

> "the GITHUB_TOKEN will not have permission to push the package if you have previously pushed a package to the same namespace, but have not connected the package to the repository ... we recommend adding the label `org.opencontainers.image.source` to your Dockerfile."

The fix: add `LABEL org.opencontainers.image.source="https://github.com/bluet/proxybroker2"` to the `Dockerfile`. This connects the image to its source repo on first push, granting the workflow's `GITHUB_TOKEN` the right scope.

(I had previously guessed it was a workflow-permissions setting; that was wrong — the maintainer correctly pointed out that "Read and write permissions" was already enabled. The actual cause is the missing OCI label, per docs. Apologies for the noise.)

### (b) Bump all actions to Node 24

GitHub announced that **Node.js 20 actions will be force-migrated to Node 24 starting 2026-06-02**, with Node 20 fully removed **2026-09-16**. The CI run on PR #204 surfaced this warning. Bumping every action used across all four workflows to its latest major (which uses Node 24):

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | **v6.0.2** |
| `actions/setup-python` | v5 | **v6.2.0** |
| `actions/upload-artifact` | v4 | **v7.0.1** |
| `docker/setup-qemu-action` | v3 | **v4.0.0** |
| `docker/setup-buildx-action` | v3 | **v4.0.0** |
| `docker/login-action` | v3 | **v4.1.0** |
| `docker/metadata-action` | v5 | **v6.0.0** |
| `docker/build-push-action` | v5 | **v7.1.0** |
| `snok/install-poetry` | v1.4.1 (tag) | v1.4.1 (SHA-pinned) |

All bumps are SHA-pinned with a trailing tag comment for readability. Dependabot is already configured (in #204) to bundle future bumps into a single monthly PR.

Files touched:
- `.github/workflows/docker-publish.yml` — 7 actions
- `.github/workflows/python-publish.yml` — 2 actions
- `.github/workflows/python-test-versions.yml` — 3 actions
- `.github/workflows/py-to-exe.yml` — 4 actions
- `.github/workflows/claude.yml` — 1 action (`actions/checkout` only — leaves `anthropics/claude-code-action@beta` floating-tag alone since beta tracking is intentional)
- `Dockerfile` — added the OCI source label

## Test plan

- [ ] Merge this PR
- [ ] Re-fire the v2.0.0b2 release: `gh release delete v2.0.0b2 --repo bluet/proxybroker2 --yes --cleanup-tag=false && gh release create v2.0.0b2 --repo bluet/proxybroker2 --prerelease --title "v2.0.0b2 — Custom Provider System & Quality Pass" --notes-file /tmp/v2.0.0b2-notes.md`
- [ ] Verify `bluet/proxybroker2:2.0.0b2` + `:2.0` + `:2` + `:latest` on https://hub.docker.com/r/bluet/proxybroker2/tags
- [ ] Verify `ghcr.io/bluet/proxybroker2:2.0.0b2` + same on https://github.com/bluet/proxybroker2/pkgs/container/proxybroker2 (first-time package creation should succeed now with the OCI label)
- [ ] Pull and run on amd64 + arm64

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows to use pinned versions for improved build stability and reproducibility across CI/CD pipelines.
  * Enhanced container image metadata to improve source tracking and integration with container registries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->