### PR TITLE
feat(ipv6): full IPv6 support across the stack (#201)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -217,3 +217,23 @@ docs/source/_autosummary/
 *~
 *.swp
 *.swo
+
+# Local working scratch (debug docs, logs, scan reports). Excluded from
+# git so security scanners and contributors don't see false positives
+# from cached scan outputs left in the working tree.
+tmp/
+
+# Claude Code local config (per-machine; never in repo).
+.claude/
+
+# Local virtualenvs that aren't `.venv` (the canonical name). Older
+# branches sometimes leave `venv/`, `venv_py313_test/`, etc.; these
+# accumulate stale dependency metadata that pollutes vulnerability
+# scanners with already-superseded CVEs.
+venv/
+venv_*/
+
+# Security scan output artifacts (gitleaks/grype/semgrep/checkov/
+# hadolint). Sometimes committed accidentally; always regeneratable.
+*-report.json
+*-stderr.txt

--- a/.gitignore
+++ b/.gitignore
@@ -237,3 +237,7 @@ venv_*/
 # hadolint). Sometimes committed accidentally; always regeneratable.
 *-report.json
 *-stderr.txt
+
+# uv-managed venv lockfile. Project uses poetry.lock as the canonical
+# lockfile; committing both creates ambiguity for contributors.
+uv.lock

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,24 @@
+# Gitleaks config: extend the default ruleset with an allowlist of
+# paths that contain known false positives. Same scope as
+# .gitignore / .semgrepignore additions in the IPv6 work (#212).
+
+[extend]
+# Inherit gitleaks' bundled default ruleset.
+useDefault = true
+
+[allowlist]
+description = "Paths excluded from gitleaks scans"
+paths = [
+    # Claude Code per-machine config. May contain short-lived AWS STS
+    # session tokens for tool integrations (Opsera S3 upload URLs etc.);
+    # never in repo, expires fast, not a real credential leak.
+    '''^\.claude/.*''',
+    # Local working scratch. Regenerated scan reports echo example
+    # AWS-key-shaped strings back at the scanner (recursive false
+    # positive).
+    '''^tmp/.*''',
+    # Stale local virtualenvs.
+    '''^\.venv/.*''',
+    '''^venv/.*''',
+    '''^venv_.*/.*''',
+]

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,15 @@
+# Scan-output artifacts contain example AWS-key-shaped strings that
+# semgrep would otherwise flag as secrets — recursive false positive.
+tmp/
+*-report.json
+*-stderr.txt
+
+# Claude Code local config (per-machine; not in repo). May contain
+# placeholder credentials in example settings.
+.claude/
+
+# Stale local virtualenvs accumulate already-superseded dependency
+# metadata that's not in pyproject.toml.
+.venv/
+venv/
+venv_*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,27 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Happy Eyeballs DNS** (RFC 8305 § 3) in `Resolver.resolve()` (#201).
-  When the caller doesn't pin `qtype`, A and AAAA queries fire in
-  parallel; the first non-empty answer wins; the slower task is
-  cancelled. Replaces sequential A→AAAA fallback - eliminates the
-  full DNS round-trip latency for v6-only hostnames and shaves the
-  worst-case latency for dual-stack hosts on broken networks.
-- **Modern type hints** on `canonicalize_ip`, `find_proxy_pairs`,
-  `_format_host_port` (PEP 604 union syntax). Better IDE/mypy
-  ergonomics for downstream consumers.
-
-### Changed
-- `find_proxy_pairs(text)` now canonicalises both IPv4 AND IPv6
-  entries (#201). IPv4 canonical form equals identity, so legacy
-  v4-only feeds see no behavior change - the contract is just
-  consistent now: every returned `(ip, port)` has a canonical IP.
-- `Socks4Ngtr.negotiate(ip=v6, ...)` raises `BadResponseError(
-  "SOCKS4 protocol does not support IPv6 destinations")` instead
-  of a cryptic `OSError` from `inet_aton` (#201). Logs point users
-  at SOCKS5 for IPv6.
-
-### Added
 - **Full IPv6 support across the stack** (#201). IPv6 is now first-class
   alongside IPv4 across detection, validation, anonymity comparison,
   SOCKS5 proxying, and `[v6]:port` provider parsing.
@@ -46,9 +25,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     returning canonical form so equivalent encodings collapse to a
     single set element.
   - `IPv6BracketedPortPattern` and the new `find_proxy_pairs(text)`
-    helper extract `[v6]:port` proxy pairs from text. Wired into the
+    helper extract `[v6]:port` proxy pairs from text (including
+    link-local zone IDs like `[fe80::1%eth0]:8080`). Wired into the
     base `Provider._find_proxies` and into `Broker._load`'s file/raw
     string parsing so every provider feed can surface IPv6 proxies.
+    Bracketed IPv6 spans are masked from the IPv4 line regex to
+    prevent IPv4-mapped IPv6 addresses (`[::ffff:1.2.3.4]:8080`)
+    from spawning a phantom IPv4 entry.
   - `_get_anonymity_lvl` and `Judge.check` now use canonical-form set
     membership instead of raw substring matching, so v6 leaks are
     correctly classified regardless of how the judge formatted the
@@ -59,17 +42,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     output is unambiguous.
   - `Socks5Ngtr` emits `ATYP=0x04` + 16-byte address for IPv6
     destinations (`ATYP=0x01` + 4-byte for IPv4 unchanged), unblocking
-    SOCKS5 connections to IPv6 origins. SOCKS4 stays IPv4-only by spec
-    (RFC 1928 has no v6 ATYP).
-
-### Removed
-- **`IPv6Pattern` 700-character regex** (#201) and its
-  `# nosemgrep: regex_dos` suppression. The pattern carried many
-  capture groups so `re.findall` returned tuples (not strings) and
-  IPv6 entries silently never matched. Replaced by the narrow
-  `_IPV6_CANDIDATE_PATTERN` tokenizer + stdlib `ipaddress` validator.
+    SOCKS5 connections to IPv6 origins. Reply ATYP read from the
+    *response* (not the request) per RFC 1928 § 6 — dual-stack
+    proxies may bind a different family. SOCKS4 stays IPv4-only by
+    spec (the SOCKS4 protocol predates IPv6 and only defines a 4-byte
+    address field; ATYP=0x04 is a SOCKS5/RFC-1928-only construct).
+  - **Happy Eyeballs DNS** (RFC 8305 § 3) in `Resolver.resolve()`.
+    When the caller doesn't pin `qtype` or `family`, A and AAAA
+    queries fire in parallel; the first non-empty answer wins; the
+    slower task is cancelled. Callers that explicitly pass
+    `qtype="A"` or `family=socket.AF_INET[/INET6]` get the
+    single-family path, preserving the legacy A-only contract.
+- **Modern type hints** on `canonicalize_ip`, `find_proxy_pairs`,
+  `_format_host_port` (PEP 604 union syntax). Better IDE/mypy
+  ergonomics for downstream consumers.
 
 ### Changed
+- `find_proxy_pairs(text)` now canonicalises both IPv4 AND IPv6
+  entries (#201). IPv4 canonical form equals identity, so legacy
+  v4-only feeds see no behavior change — the contract is just
+  consistent now: every returned `(ip, port)` has a canonical IP.
+- `Socks4Ngtr.negotiate(ip=v6, ...)` raises `BadResponseError(
+  "SOCKS4 protocol does not support IPv6 destinations")` instead
+  of a cryptic `OSError` from `inet_aton` (#201). Logs point users
+  at SOCKS5 for IPv6.
 - `Resolver.host_is_ip` legacy behavior preserved for IPv4 with leading
   zeros (e.g. `127.0.0.001`); accepted by the wrapper even though
   CPython 3.9.5+ rejects them under CVE-2021-29921. Documented in the
@@ -77,6 +73,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `judge.py:Judge.check` and `checker.py:_get_anonymity_lvl` now log
   the boolean visibility result (rather than the substring expression)
   for symmetry with how the v6 set-membership comparison is done.
+
+### Removed
+- **`IPv6Pattern` 700-character regex** (#201) and its
+  `# nosemgrep: regex_dos` suppression. The pattern carried many
+  capture groups so `re.findall` returned tuples (not strings) and
+  IPv6 entries silently never matched. Replaced by the narrow
+  `_IPV6_CANDIDATE_PATTERN` tokenizer + stdlib `ipaddress` validator.
 
 ## [2.0.0b2] - 2026-05-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Happy Eyeballs DNS** (RFC 8305 § 3) in `Resolver.resolve()` (#201).
+  When the caller doesn't pin `qtype`, A and AAAA queries fire in
+  parallel; the first non-empty answer wins; the slower task is
+  cancelled. Replaces sequential A→AAAA fallback - eliminates the
+  full DNS round-trip latency for v6-only hostnames and shaves the
+  worst-case latency for dual-stack hosts on broken networks.
+- **Modern type hints** on `canonicalize_ip`, `find_proxy_pairs`,
+  `_format_host_port` (PEP 604 union syntax). Better IDE/mypy
+  ergonomics for downstream consumers.
+
+### Changed
+- `find_proxy_pairs(text)` now canonicalises both IPv4 AND IPv6
+  entries (#201). IPv4 canonical form equals identity, so legacy
+  v4-only feeds see no behavior change - the contract is just
+  consistent now: every returned `(ip, port)` has a canonical IP.
+- `Socks4Ngtr.negotiate(ip=v6, ...)` raises `BadResponseError(
+  "SOCKS4 protocol does not support IPv6 destinations")` instead
+  of a cryptic `OSError` from `inet_aton` (#201). Logs point users
+  at SOCKS5 for IPv6.
+
+### Added
 - **Full IPv6 support across the stack** (#201). IPv6 is now first-class
   alongside IPv4 across detection, validation, anonymity comparison,
   SOCKS5 proxying, and `[v6]:port` provider parsing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,11 +27,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `IPv6BracketedPortPattern` and the new `find_proxy_pairs(text)`
     helper extract `[v6]:port` proxy pairs from text (including
     link-local zone IDs like `[fe80::1%eth0]:8080`). Wired into the
-    base `Provider._find_proxies` and into `Broker._load`'s file/raw
-    string parsing so every provider feed can surface IPv6 proxies.
-    Bracketed IPv6 spans are masked from the IPv4 line regex to
-    prevent IPv4-mapped IPv6 addresses (`[::ffff:1.2.3.4]:8080`)
-    from spawning a phantom IPv4 entry.
+    public `Provider.find_proxies` (kept out of the lower-level
+    `_find_proxies` raw-regex helper so subclasses that pipe its
+    output through `b64decode`/custom decoders aren't fed
+    already-normalized `(host, port)` tuples) and into
+    `Broker._load`'s file/raw string parsing so every provider feed
+    can surface IPv6 proxies. Bracketed IPv6 spans are masked from
+    the IPv4 line regex in both paths to prevent IPv4-mapped IPv6
+    addresses (`[::ffff:1.2.3.4]:8080`) from spawning a phantom IPv4
+    entry.
   - `_get_anonymity_lvl` and `Judge.check` now use canonical-form set
     membership instead of raw substring matching, so v6 leaks are
     correctly classified regardless of how the judge formatted the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Full IPv6 support across the stack** (#201). IPv6 is now first-class
+  alongside IPv4 across detection, validation, anonymity comparison,
+  SOCKS5 proxying, and `[v6]:port` provider parsing.
+  - `Resolver.host_is_ip()` accepts both IPv4 and IPv6 literals
+    (loopback `::1`, documentation prefix `2001:db8::1`, IPv4-mapped
+    `::ffff:192.0.2.1`, link-local with zone IDs `fe80::1%eth0`).
+  - `Resolver.get_real_ext_ip()` returns RFC 5952 canonical form and
+    accepts IPv6 responses from upstream IP-detection services. Adds
+    `https://api64.ipify.org/` to the default endpoints so proxybroker
+    works on IPv6-only networks.
+  - `proxybroker/utils.py`: new `canonicalize_ip(s) -> str | None`
+    helper exposes the RFC 5952 canonical form via stdlib `ipaddress`.
+    `get_all_ip()` rewritten to extract IPv4 substrings (legacy
+    contract) plus IPv6 candidates validated through `ipaddress`,
+    returning canonical form so equivalent encodings collapse to a
+    single set element.
+  - `IPv6BracketedPortPattern` and the new `find_proxy_pairs(text)`
+    helper extract `[v6]:port` proxy pairs from text. Wired into the
+    base `Provider._find_proxies` and into `Broker._load`'s file/raw
+    string parsing so every provider feed can surface IPv6 proxies.
+  - `_get_anonymity_lvl` and `Judge.check` now use canonical-form set
+    membership instead of raw substring matching, so v6 leaks are
+    correctly classified regardless of how the judge formatted the
+    address (uppercase, expanded with leading zeros, with or without
+    `::` compression).
+  - `Proxy(host=...)` accepts IPv6 literals; `as_text()`, `__repr__()`
+    and `Proxy.log` bracket IPv6 hosts per RFC 3986 § 3.2.2 so the
+    output is unambiguous.
+  - `Socks5Ngtr` emits `ATYP=0x04` + 16-byte address for IPv6
+    destinations (`ATYP=0x01` + 4-byte for IPv4 unchanged), unblocking
+    SOCKS5 connections to IPv6 origins. SOCKS4 stays IPv4-only by spec
+    (RFC 1928 has no v6 ATYP).
+
+### Removed
+- **`IPv6Pattern` 700-character regex** (#201) and its
+  `# nosemgrep: regex_dos` suppression. The pattern carried many
+  capture groups so `re.findall` returned tuples (not strings) and
+  IPv6 entries silently never matched. Replaced by the narrow
+  `_IPV6_CANDIDATE_PATTERN` tokenizer + stdlib `ipaddress` validator.
+
+### Changed
+- `Resolver.host_is_ip` legacy behavior preserved for IPv4 with leading
+  zeros (e.g. `127.0.0.001`); accepted by the wrapper even though
+  CPython 3.9.5+ rejects them under CVE-2021-29921. Documented in the
+  docstring; some provider feeds in the wild still emit that form.
+- `judge.py:Judge.check` and `checker.py:_get_anonymity_lvl` now log
+  the boolean visibility result (rather than the substring expression)
+  for symmetry with how the v6 set-membership comparison is done.
+
 ## [2.0.0b2] - 2026-05-08
 
 🎯 **Custom Provider System & Quality Pass**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,24 @@ PROVIDERS if providers is None else providers
 ### Protocol Priority
 Deterministic order: SOCKS5 → SOCKS4 → CONNECT:80 → CONNECT:25 → HTTPS → HTTP
 
+### IPv6 Support
+First-class alongside IPv4 across the stack (PR for #201). Key invariants:
+- **Canonical form is RFC 5952** (`str(ipaddress.ip_address(...))`):
+  lowercase, leading-zeros stripped, longest zero-run as `::`. Use
+  `proxybroker.utils.canonicalize_ip(s) -> str | None` at every
+  boundary where IPs cross from text into comparison.
+- **IPv4 contracts are preserved**. `IPPattern.findall` still handles
+  the legacy substring extraction (e.g. `127.0.0.1` from `127.0.0.1:80`).
+  Canonical form for IPv4 is identity, so set membership behavior is
+  unchanged for the IPv4 path.
+- **IPv6 in URI authority MUST be bracketed** (RFC 3986). `Proxy.as_text`,
+  `Proxy.__repr__`, and proxy-list output all bracket v6 hosts.
+- **SOCKS5 `ATYP=0x04`** for IPv6 destinations; SOCKS4 stays IPv4-only
+  by spec (no v6 ATYP in RFC 1928).
+- **Provider feeds**: `[v6]:port` is parsed via `IPv6BracketedPortPattern`
+  + stdlib validation. Helper `find_proxy_pairs(text)` returns
+  `[(ip_canonical, port), ...]` for both v4 and v6.
+
 ### Signal Handler Cleanup
 `Broker.stop()` properly removes signal handlers to prevent memory leaks
 

--- a/proxybroker/api.py
+++ b/proxybroker/api.py
@@ -12,7 +12,12 @@ from .providers import PROVIDERS, Provider
 from .proxy import Proxy
 from .resolver import Resolver
 from .server import Server
-from .utils import IPPortPatternLine, log
+from .utils import (
+    IPPortPatternLine,
+    IPv6BracketedPortPattern,
+    canonicalize_ip,
+    log,
+)
 
 # Pause between grabbing cycles; in seconds.
 GRAB_PAUSE = 180
@@ -374,7 +379,13 @@ class Broker:
         if isinstance(data, io.TextIOWrapper):
             data = data.read()
         if isinstance(data, str):
-            data = IPPortPatternLine.findall(data)
+            v4_pairs = IPPortPatternLine.findall(data)
+            v6_pairs = []
+            for raw_v6, port in IPv6BracketedPortPattern.findall(data):
+                canonical = canonicalize_ip(raw_v6)
+                if canonical is not None:
+                    v6_pairs.append((canonical, port))
+            data = v4_pairs + v6_pairs
         proxies = set(data)
         for proxy in proxies:
             await self._handle(proxy, check=check)

--- a/proxybroker/api.py
+++ b/proxybroker/api.py
@@ -379,12 +379,21 @@ class Broker:
         if isinstance(data, io.TextIOWrapper):
             data = data.read()
         if isinstance(data, str):
-            v4_pairs = IPPortPatternLine.findall(data)
+            # Extract bracketed v6 entries first, then mask their spans
+            # in the input before running the v4 line regex. Without
+            # masking, an IPv4-mapped v6 entry like `[::ffff:1.2.3.4]:8080`
+            # would also produce a phantom v4 entry `1.2.3.4:8080` from
+            # the embedded literal. RFC 6874 zone IDs in brackets are
+            # accepted by the regex; validation is via canonicalize_ip.
             v6_pairs = []
             for raw_v6, port in IPv6BracketedPortPattern.findall(data):
                 canonical = canonicalize_ip(raw_v6)
                 if canonical is not None:
                     v6_pairs.append((canonical, port))
+            v4_input = IPv6BracketedPortPattern.sub(
+                lambda m: " " * len(m.group(0)), data
+            )
+            v4_pairs = IPPortPatternLine.findall(v4_input)
             data = v4_pairs + v6_pairs
         proxies = set(data)
         for proxy in proxies:

--- a/proxybroker/checker.py
+++ b/proxybroker/checker.py
@@ -16,7 +16,14 @@ from .errors import (
 from .judge import Judge, get_judges
 from .negotiators import NGTRS
 from .resolver import Resolver
-from .utils import get_all_ip, get_headers, get_status_code, log, parse_headers
+from .utils import (
+    canonicalize_ip,
+    get_all_ip,
+    get_headers,
+    get_status_code,
+    log,
+    parse_headers,
+)
 
 
 class Checker:
@@ -316,12 +323,17 @@ def _check_test_response(proxy, headers, content, rv):
 def _get_anonymity_lvl(real_ext_ip, proxy, judge, content):
     content = content.lower()
     foundIP = get_all_ip(content)
+    # Defense in depth: canonicalise the real IP even if the caller already
+    # passed canonical form. Comparison must be canonical-vs-canonical so
+    # IPv6 textual encodings (case, leading zeros, compression) compare
+    # equal. Falls back to the raw value only if canonicalisation fails.
+    real_canonical = canonicalize_ip(real_ext_ip) or real_ext_ip
 
     via = (content.count("via") > judge.marks["via"]) or (
         content.count("proxy") > judge.marks["proxy"]
     )
 
-    if real_ext_ip in foundIP:
+    if real_canonical in foundIP:
         lvl = "Transparent"
     elif via:
         lvl = "Anonymous"

--- a/proxybroker/judge.py
+++ b/proxybroker/judge.py
@@ -6,7 +6,7 @@ import aiohttp
 
 from .errors import ResolveError
 from .resolver import Resolver
-from .utils import get_headers, log
+from .utils import canonicalize_ip, get_all_ip, get_headers, log
 
 
 class Judge:
@@ -107,8 +107,16 @@ class Judge:
             return
 
         page = page.lower()
+        # Use canonical-form set membership instead of substring `in page`
+        # so we correctly recognise IPv6 echoes regardless of how the
+        # judge formatted them (uppercase, expanded, compressed). For
+        # IPv4, canonical form equals the raw form, so behavior is
+        # preserved for the legacy v4 path.
+        page_ips = get_all_ip(page)
+        real_canonical = canonicalize_ip(real_ext_ip) or real_ext_ip
+        real_ip_visible = real_canonical in page_ips
 
-        if resp.status == 200 and real_ext_ip in page and rv in page:
+        if resp.status == 200 and real_ip_visible and rv in page:
             self.marks["via"] = page.count("via")
             self.marks["proxy"] = page.count("proxy")
             self.is_working = True
@@ -118,7 +126,7 @@ class Judge:
         else:
             log.debug(
                 f"{self} is failed. HTTP status code: {resp.status}; "
-                f"Real IP on page: {real_ext_ip in page}; Version: {rv in page}; "
+                f"Real IP on page: {real_ip_visible}; Version: {rv in page}; "
                 f"Response: {page}"
             )
 

--- a/proxybroker/negotiators.py
+++ b/proxybroker/negotiators.py
@@ -23,20 +23,23 @@ SMTP_READY = 220
 
 def _CONNECT_request(host, port, **kwargs):
     kwargs.setdefault("User-Agent", get_headers()["User-Agent"])
-    kw = {
-        "host": host,
-        "port": port,
-        "headers": "\r\n".join((f"{k}: {v}" for k, v in kwargs.items())),
-    }
-    req = (
-        (
-            "CONNECT {host}:{port} HTTP/1.1\r\nHost: {host}\r\n"
-            "{headers}\r\nConnection: keep-alive\r\n\r\n"
-        )
-        .format(**kw)
-        .encode()
-    )
-    return req
+    # RFC 9112 § 3.2.3 (request-target authority-form) and RFC 9110 § 7.2
+    # (Host header field) both require IPv6 literals to be bracketed in
+    # URI authority components. Without brackets, "CONNECT 2001:db8::1:443"
+    # is ambiguous (where does the host end and the port begin?) and
+    # standards-compliant proxies will reject it.
+    if ":" in str(host):
+        authority = f"[{host}]:{port}"
+        host_header = f"[{host}]"
+    else:
+        authority = f"{host}:{port}"
+        host_header = f"{host}"
+    headers = "\r\n".join(f"{k}: {v}" for k, v in kwargs.items())
+    return (
+        f"CONNECT {authority} HTTP/1.1\r\n"
+        f"Host: {host_header}\r\n"
+        f"{headers}\r\nConnection: keep-alive\r\n\r\n"
+    ).encode()
 
 
 class BaseNegotiator(ABC):

--- a/proxybroker/negotiators.py
+++ b/proxybroker/negotiators.py
@@ -28,12 +28,20 @@ def _CONNECT_request(host, port, **kwargs):
     # URI authority components. Without brackets, "CONNECT 2001:db8::1:443"
     # is ambiguous (where does the host end and the port begin?) and
     # standards-compliant proxies will reject it.
-    if ":" in str(host):
-        authority = f"[{host}]:{port}"
-        host_header = f"[{host}]"
+    #
+    # Strip any caller-supplied brackets first so callers passing values
+    # straight from `urlparse('https://[2001:db8::1]/').netloc` (already
+    # bracketed) don't end up with double brackets like
+    # `[[2001:db8::1]]:443`.
+    host_str = str(host)
+    if host_str.startswith("[") and host_str.endswith("]"):
+        host_str = host_str[1:-1]
+    if ":" in host_str:
+        authority = f"[{host_str}]:{port}"
+        host_header = f"[{host_str}]"
     else:
-        authority = f"{host}:{port}"
-        host_header = f"{host}"
+        authority = f"{host_str}:{port}"
+        host_header = f"{host_str}"
     headers = "\r\n".join(f"{k}: {v}" for k, v in kwargs.items())
     return (
         f"CONNECT {authority} HTTP/1.1\r\n"

--- a/proxybroker/negotiators.py
+++ b/proxybroker/negotiators.py
@@ -91,15 +91,30 @@ class Socks5Ngtr(BaseNegotiator):
         )
 
         await self._proxy.send(request)
-        # Reply size: VER(1)+REP(1)+RSV(1)+ATYP(1)+BND.ADDR(4 or 16)+BND.PORT(2)
-        reply_size = 22 if atyp == 0x04 else 10
-        resp = await self._proxy.recv(reply_size)
-
-        if resp[0] != 0x05 or resp[1] != 0x00:
+        # Per RFC 1928 § 6, the reply's BND.ADDR can be a different
+        # address family from the client's request - dual-stack proxies
+        # may bind to v6 even when the client requested v4 (or vice
+        # versa). So we must read the 4-byte fixed header first
+        # (VER+REP+RSV+ATYP), inspect the *response* ATYP, then read
+        # the variable-length BND.ADDR + BND.PORT.
+        header = await self._proxy.recv(4)
+        if header[0] != 0x05 or header[1] != 0x00:
             self._proxy.log("Failed (invalid data)", err=BadResponseError)
             raise BadResponseError
+        rep_atyp = header[3]
+        if rep_atyp == 0x01:  # IPv4
+            addr_len = 4
+        elif rep_atyp == 0x04:  # IPv6
+            addr_len = 16
+        elif rep_atyp == 0x03:  # Domain name (1-byte length prefix)
+            length = await self._proxy.recv(1)
+            addr_len = length[0]
         else:
-            self._proxy.log("Request is granted")
+            self._proxy.log("Failed (invalid data)", err=BadResponseError)
+            raise BadResponseError
+        # Drain BND.ADDR + BND.PORT (2 bytes); we don't use them.
+        await self._proxy.recv(addr_len + 2)
+        self._proxy.log("Request is granted")
 
 
 class Socks4Ngtr(BaseNegotiator):

--- a/proxybroker/negotiators.py
+++ b/proxybroker/negotiators.py
@@ -1,4 +1,5 @@
 import asyncio
+import ipaddress
 import struct
 from abc import ABC, abstractmethod
 from socket import inet_aton
@@ -71,11 +72,25 @@ class Socks5Ngtr(BaseNegotiator):
             self._proxy.log("Failed (invalid data)", err=BadResponseError)
             raise BadResponseError
 
-        bip = inet_aton(kwargs.get("ip"))
+        # SOCKS5 (RFC 1928) supports IPv4 (ATYP=0x01, 4 bytes) and IPv6
+        # (ATYP=0x04, 16 bytes). We dispatch on `ipaddress.ip_address`
+        # rather than catching `inet_aton` failures so the encoding is
+        # explicit and v6-only callers don't pay an exception round-trip.
+        addr = ipaddress.ip_address(kwargs.get("ip"))
         port = kwargs.get("port", 80)
+        if isinstance(addr, ipaddress.IPv6Address):
+            atyp = 0x04
+        else:
+            atyp = 0x01
+        # VER(1) + CMD(1) + RSV(1) + ATYP(1) + ADDR(4 or 16) + PORT(2)
+        request = (
+            struct.pack(">4B", 5, 1, 0, atyp) + addr.packed + struct.pack(">H", port)
+        )
 
-        await self._proxy.send(struct.pack(">8BH", 5, 1, 0, 1, *bip, port))
-        resp = await self._proxy.recv(10)
+        await self._proxy.send(request)
+        # Reply size: VER(1)+REP(1)+RSV(1)+ATYP(1)+BND.ADDR(4 or 16)+BND.PORT(2)
+        reply_size = 22 if atyp == 0x04 else 10
+        resp = await self._proxy.recv(reply_size)
 
         if resp[0] != 0x05 or resp[1] != 0x00:
             self._proxy.log("Failed (invalid data)", err=BadResponseError)

--- a/proxybroker/negotiators.py
+++ b/proxybroker/negotiators.py
@@ -103,12 +103,31 @@ class Socks5Ngtr(BaseNegotiator):
 
 
 class Socks4Ngtr(BaseNegotiator):
-    """SOCKS4 Negotiator."""
+    """SOCKS4 Negotiator.
+
+    SOCKS4 (RFC 1928 lacks SOCKS4; original Ying-Da Lee spec) only
+    defines a 4-byte IPv4 address field - there is no ATYP byte and
+    no IPv6 address type. Callers attempting v6 destinations get a
+    domain-specific BadResponseError instead of a cryptic
+    `OSError: illegal IP address string passed to inet_aton`.
+    """
 
     name = "SOCKS4"
 
     async def negotiate(self, **kwargs):
-        bip = inet_aton(kwargs.get("ip"))
+        ip = kwargs.get("ip")
+        try:
+            addr = ipaddress.ip_address(ip) if ip else None
+        except ValueError:
+            addr = None
+        if isinstance(addr, ipaddress.IPv6Address):
+            self._proxy.log(
+                "Failed (SOCKS4 does not support IPv6 destinations; "
+                "use SOCKS5 for IPv6)",
+                err=BadResponseError,
+            )
+            raise BadResponseError("SOCKS4 protocol does not support IPv6 destinations")
+        bip = inet_aton(ip)
         port = kwargs.get("port", 80)
 
         await self._proxy.send(struct.pack(">2BH5B", 4, 1, port, *bip, 0))

--- a/proxybroker/providers.py
+++ b/proxybroker/providers.py
@@ -166,7 +166,13 @@ class Provider:
         # in the public method so subclasses that override `find_proxies`
         # to do their own decoding (b64, custom parsing) aren't fed
         # already-normalized (host, port) tuples they can't handle.
-        proxies = self._find_proxies(page)
+        #
+        # Mask bracketed IPv6 spans before the IPv4 pass so feeds carrying
+        # IPv4-mapped IPv6 entries like `[::ffff:192.0.2.1]:8080` don't
+        # *also* enqueue a phantom `192.0.2.1:8080` IPv4 entry that the
+        # provider never advertised.
+        masked = IPv6BracketedPortPattern.sub(lambda m: " " * len(m.group(0)), page)
+        proxies = self._find_proxies(masked)
         for raw_v6, port in IPv6BracketedPortPattern.findall(page):
             canonical = canonicalize_ip(raw_v6)
             if canonical is not None:

--- a/proxybroker/providers.py
+++ b/proxybroker/providers.py
@@ -161,21 +161,20 @@ class Provider:
         return page
 
     def find_proxies(self, page):
-        return self._find_proxies(page)
-
-    def _find_proxies(self, page):
-        # Default IPv4 extraction via the legacy pattern (subclasses may
-        # override `_pattern` for source-specific HTML quirks). IPv6
-        # entries in `[v6]:port` form are extracted in addition - they
-        # are validated and canonicalised via stdlib `ipaddress` so
-        # invalid bracketed garbage is silently dropped rather than
-        # surfacing as proxy candidates.
-        proxies = list(self._pattern.findall(page))
+        # Default IPv4 extraction via _find_proxies (subclasses may
+        # override `_pattern`), then add IPv6 `[v6]:port` entries here
+        # in the public method so subclasses that override `find_proxies`
+        # to do their own decoding (b64, custom parsing) aren't fed
+        # already-normalized (host, port) tuples they can't handle.
+        proxies = self._find_proxies(page)
         for raw_v6, port in IPv6BracketedPortPattern.findall(page):
             canonical = canonicalize_ip(raw_v6)
             if canonical is not None:
                 proxies.append((canonical, port))
         return proxies
+
+    def _find_proxies(self, page):
+        return list(self._pattern.findall(page))
 
 
 class Freeproxylists_com(Provider):

--- a/proxybroker/providers.py
+++ b/proxybroker/providers.py
@@ -9,7 +9,14 @@ from urllib.parse import unquote, urlparse
 import aiohttp
 
 from .errors import BadStatusError
-from .utils import IPPattern, IPPortPatternGlobal, get_headers, log
+from .utils import (
+    IPPattern,
+    IPPortPatternGlobal,
+    IPv6BracketedPortPattern,
+    canonicalize_ip,
+    get_headers,
+    log,
+)
 
 
 class Provider:
@@ -157,7 +164,17 @@ class Provider:
         return self._find_proxies(page)
 
     def _find_proxies(self, page):
-        proxies = self._pattern.findall(page)
+        # Default IPv4 extraction via the legacy pattern (subclasses may
+        # override `_pattern` for source-specific HTML quirks). IPv6
+        # entries in `[v6]:port` form are extracted in addition - they
+        # are validated and canonicalised via stdlib `ipaddress` so
+        # invalid bracketed garbage is silently dropped rather than
+        # surfacing as proxy candidates.
+        proxies = list(self._pattern.findall(page))
+        for raw_v6, port in IPv6BracketedPortPattern.findall(page):
+            canonical = canonicalize_ip(raw_v6)
+            if canonical is not None:
+                proxies.append((canonical, port))
         return proxies
 
 

--- a/proxybroker/proxy.py
+++ b/proxybroker/proxy.py
@@ -20,6 +20,20 @@ _HTTP_PROTOS = {"HTTP", "CONNECT:80", "SOCKS4", "SOCKS5"}
 _HTTPS_PROTOS = {"HTTPS", "SOCKS4", "SOCKS5"}
 
 
+def _format_host_port(host, port):
+    """Format `host:port` with RFC 3986 IPv6 bracketing.
+
+    IPv6 literals contain colons, which would ambiguate against the
+    port separator. RFC 3986 § 3.2.2 mandates `[host]:port` for IPv6
+    in URI authority components; we use the same form everywhere so
+    proxy strings paste cleanly into clients that expect URI syntax.
+    IPv4 hosts pass through unchanged.
+    """
+    if ":" in str(host):
+        return f"[{host}]:{port}"
+    return f"{host}:{port}"
+
+
 # nosemgrep: python.lang.security.unverified-ssl-context.unverified-ssl-context
 def _make_unverified_ssl_context_for_proxy_testing():
     """Build an SSL context that skips cert + hostname verification.
@@ -138,7 +152,7 @@ class Proxy:
             s = s.format(tp=tp, lvl=lvl)
             tpinfo.append(s)
         tpinfo = ", ".join(tpinfo)
-        return f"<Proxy {self._geo.code} {self.avg_resp_time:.2f}s [{tpinfo}] {self.host}:{self.port}>"
+        return f"<Proxy {self._geo.code} {self.avg_resp_time:.2f}s [{tpinfo}] {_format_host_port(self.host, self.port)}>"
 
     @property
     def types(self):
@@ -299,16 +313,19 @@ class Proxy:
 
     def as_text(self):
         """
-        Return proxy as host:port
+        Return proxy as host:port (IPv6 bracketed per RFC 3986).
 
         :rtype: str
         """
-        return f"{self.host}:{self.port}\n"
+        return f"{_format_host_port(self.host, self.port)}\n"
 
     def log(self, msg, stime=0, err=None):
         ngtr = self.ngtr.name if self.ngtr else "INFO"
         runtime = time.time() - stime if stime else 0
-        log.debug(f"{self.host}:{self.port} [{ngtr}]: {msg}; Runtime: {runtime:.2f}")
+        log.debug(
+            f"{_format_host_port(self.host, self.port)} [{ngtr}]: {msg}; "
+            f"Runtime: {runtime:.2f}"
+        )
         trunc = "..." if len(msg) > 58 else ""
         msg = f"{msg:.60s}{trunc}"
         self._log.append((ngtr, msg, runtime))

--- a/proxybroker/proxy.py
+++ b/proxybroker/proxy.py
@@ -20,7 +20,7 @@ _HTTP_PROTOS = {"HTTP", "CONNECT:80", "SOCKS4", "SOCKS5"}
 _HTTPS_PROTOS = {"HTTPS", "SOCKS4", "SOCKS5"}
 
 
-def _format_host_port(host, port):
+def _format_host_port(host: str, port: int | str) -> str:
     """Format `host:port` with RFC 3986 IPv6 bracketing.
 
     IPv6 literals contain colons, which would ambiguate against the

--- a/proxybroker/resolver.py
+++ b/proxybroker/resolver.py
@@ -162,7 +162,10 @@ class Resolver:
         case latency for dual-stack hosts on broken networks.
         """
         if self.host_is_ip(host):
-            return host
+            # Canonicalise the literal so callers downstream of resolve()
+            # always see RFC 5952 canonical form, regardless of how the
+            # caller wrote the input ("2001:DB8::1" vs "2001:db8::1").
+            return canonicalize_ip(host) or host
 
         _host = self._cached_hosts.get(host)
         if _host:
@@ -177,7 +180,11 @@ class Resolver:
             hosts = [
                 {
                     "hostname": host,
-                    "host": r.host,
+                    # Canonicalise DNS-returned host strings too. aiodns
+                    # may emit different textual forms across resolvers/
+                    # platforms; downstream comparison logic relies on
+                    # canonical form to dedup equivalent addresses.
+                    "host": canonicalize_ip(r.host) or r.host,
                     "port": port,
                     "family": family,
                     "proto": socket.IPPROTO_IP,

--- a/proxybroker/resolver.py
+++ b/proxybroker/resolver.py
@@ -147,7 +147,15 @@ class Resolver:
         raise RuntimeError("Could not get the external IP")
 
     async def resolve(self, host, port=80, family=None, qtype="A", logging=True):
-        """Return resolving IP address(es) from host name."""
+        """Resolve `host` to one or more IP addresses.
+
+        `qtype` defaults to "A" for backwards compatibility. When the
+        caller doesn't request a specific record type and the A query
+        returns nothing, we transparently fall back to AAAA so that
+        IPv6-only hostnames (no A records) resolve too. This restores
+        end-to-end reachability for the increasing number of services
+        that publish AAAA-only records.
+        """
         if self.host_is_ip(host):
             return host
 
@@ -155,7 +163,23 @@ class Resolver:
         if _host:
             return _host
 
-        resp = await self._resolve(host, qtype)
+        # Transparent AAAA fallback for callers that didn't pin qtype.
+        # If A succeeds, use it. If A fails *and* the caller didn't pin
+        # qtype, try AAAA - so v6-only hostnames (no A record) resolve.
+        # If AAAA also fails, propagate ResolveError to preserve the
+        # original "could not resolve" contract.
+        try:
+            resp = await self._resolve(host, qtype)
+        except ResolveError:
+            if qtype == "A":
+                resp = await self._resolve(host, "AAAA")
+            else:
+                raise
+        if not resp and qtype == "A":
+            try:
+                resp = await self._resolve(host, "AAAA")
+            except ResolveError:
+                resp = None
 
         if resp:
             hosts = [

--- a/proxybroker/resolver.py
+++ b/proxybroker/resolver.py
@@ -22,6 +22,14 @@ _geo_db = _citydb if os.path.exists(_citydb) else _countrydb
 
 _mmdb_reader = maxminddb.open_database(_geo_db)
 
+# Sentinel for `Resolver.resolve(qtype=...)` so we can tell apart
+# "caller didn't specify" (default → Happy Eyeballs A+AAAA race) from
+# "caller explicitly passed qtype='A'" (legacy A-only single-query).
+# Without the sentinel, the previous `qtype="A"` default would force
+# every default call into the dual-stack race even when the caller
+# wanted the legacy contract.
+_QTYPE_DEFAULT = object()
+
 
 class Resolver:
     """Async host resolver based on aiodns."""
@@ -146,20 +154,27 @@ class Resolver:
                     return canonical
         raise RuntimeError("Could not get the external IP")
 
-    async def resolve(self, host, port=80, family=None, qtype="A", logging=True):
+    async def resolve(
+        self, host, port=80, family=None, qtype=_QTYPE_DEFAULT, logging=True
+    ):
         """Resolve `host` to one or more IP addresses.
 
-        When the caller doesn't pin a specific record type (`qtype="A"`,
-        the default), A and AAAA queries fire in parallel per Happy
-        Eyeballs DNS (RFC 8305 § 3). The first non-empty answer wins;
-        the slower query is cancelled. If both fail, the most recent
-        error is re-raised to preserve the historical "could not
-        resolve" contract.
+        When the caller doesn't pin a specific record type or address
+        family, A and AAAA queries fire in parallel per Happy Eyeballs
+        DNS (RFC 8305 § 3). The first non-empty answer wins; the slower
+        query is cancelled. If both fail, the most recent error is
+        re-raised to preserve the historical "could not resolve" contract.
 
-        Sequential fallback would add a full DNS round-trip of latency
-        for v6-only hostnames; parallel race makes v4-only and v6-only
-        hosts resolve at roughly the same speed and shaves the worst-
-        case latency for dual-stack hosts on broken networks.
+        Callers that explicitly pass `qtype="A"`, `qtype="AAAA"`, or
+        `family=socket.AF_INET[/INET6]` get the legacy single-family
+        path and never see a result from the other family. This
+        preserves the contract for callers that need A-only (or
+        AAAA-only) results.
+
+        Sequential A→AAAA fallback would add a full DNS round-trip of
+        latency for v6-only hostnames; parallel race makes v4-only and
+        v6-only hosts resolve at roughly the same speed and shaves the
+        worst-case latency for dual-stack hosts on broken networks.
         """
         if self.host_is_ip(host):
             # Canonicalise the literal so callers downstream of resolve()
@@ -171,10 +186,7 @@ class Resolver:
         if _host:
             return _host
 
-        if qtype == "A":
-            resp = await self._race_a_aaaa(host)
-        else:
-            resp = await self._resolve(host, qtype)
+        resp = await self._fetch_records(host, family, qtype)
 
         if resp:
             hosts = [
@@ -202,6 +214,23 @@ class Resolver:
             if logging:
                 log.warning(f"{host}: Could not resolve host")
         return self._cached_hosts.get(host)
+
+    async def _fetch_records(self, host, family, qtype):
+        """Choose A-only / AAAA-only / parallel race based on caller intent.
+
+        Extracted from `resolve()` to keep that method below the
+        cognitive-complexity threshold (Sonar S3776) and to make the
+        family/qtype dispatch explicit in one place.
+        """
+        if qtype is not _QTYPE_DEFAULT:
+            # Caller pinned the query type - honor it without racing.
+            return await self._resolve(host, qtype)
+        if family == socket.AF_INET:
+            return await self._resolve(host, "A")
+        if family == socket.AF_INET6:
+            return await self._resolve(host, "AAAA")
+        # Default: Happy Eyeballs (race A and AAAA).
+        return await self._race_a_aaaa(host)
 
     async def _race_a_aaaa(self, host):
         """Race A and AAAA queries; return the first non-empty answer.

--- a/proxybroker/resolver.py
+++ b/proxybroker/resolver.py
@@ -10,7 +10,7 @@ import aiohttp
 import maxminddb
 
 from .errors import ResolveError
-from .utils import DATA_DIR, log
+from .utils import DATA_DIR, canonicalize_ip, log
 
 GeoData = namedtuple(
     "GeoData", ["code", "name", "region_code", "region_name", "city_name"]
@@ -27,13 +27,18 @@ class Resolver:
     """Async host resolver based on aiodns."""
 
     _cached_hosts = {}
+    # External IP discovery endpoints. `api64.ipify.org` returns the IPv6
+    # address if the network supports it, otherwise IPv4 - so this list
+    # works for IPv4-only, IPv6-only, and dual-stack hosts. The remaining
+    # entries are IPv4-only by URL/hostname; they continue to function on
+    # dual-stack and act as fallbacks if api64 is unreachable.
     _ip_hosts = [
+        "https://api64.ipify.org/",
         "https://wtfismyip.com/text",
         "http://api.ipify.org/",
         "http://ipinfo.io/ip",
         "http://ipv4.icanhazip.com/",
         "http://myexternalip.com/raw",
-        "http://ipinfo.io/ip",
         "http://ifconfig.io/ip",
     ]
     # the list of resolvers will point a copy of original one
@@ -53,15 +58,31 @@ class Resolver:
 
     @staticmethod
     def host_is_ip(host):
-        """Check a host is IP address."""
-        # TODO: add IPv6 support
-        try:
-            host = ".".join(f"{int(n)}" for n in host.split("."))
-            ipaddress.IPv4Address(host)
-        except (ipaddress.AddressValueError, ValueError):
+        """Return True iff `host` is a valid IPv4 or IPv6 literal.
+
+        Both families use stdlib `ipaddress` for parsing. IPv4 addresses
+        with leading zeros (e.g. `"127.0.0.001"`) are also accepted by
+        normalizing octets - `ipaddress.IPv4Address` itself rejects them
+        since CPython 3.9.5 (CVE-2021-29921), but provider feeds in the
+        wild occasionally emit that form, and historical proxybroker
+        accepted it. Preserved here to avoid silently dropping proxies.
+        """
+        if not isinstance(host, str) or not host:
             return False
-        else:
+        try:
+            ipaddress.ip_address(host)
             return True
+        except ValueError:
+            pass
+        if "." in host and ":" not in host:
+            # Legacy IPv4-only normalization for octets with leading zeros.
+            try:
+                normalized = ".".join(f"{int(n)}" for n in host.split("."))
+                ipaddress.IPv4Address(normalized)
+                return True
+            except (ipaddress.AddressValueError, ValueError):
+                return False
+        return False
 
     @staticmethod
     def get_ip_info(ip):
@@ -119,12 +140,11 @@ class Resolver:
                 log.debug("Timeout getting external IP from service, trying next...")
             else:
                 ip = ip.strip()
-                if self.host_is_ip(ip):
-                    log.debug("Real external IP: %s", ip)
-                    break
-        else:
-            raise RuntimeError("Could not get the external IP")
-        return ip
+                canonical = canonicalize_ip(ip)
+                if canonical is not None:
+                    log.debug("Real external IP: %s", canonical)
+                    return canonical
+        raise RuntimeError("Could not get the external IP")
 
     async def resolve(self, host, port=80, family=None, qtype="A", logging=True):
         """Return resolving IP address(es) from host name."""

--- a/proxybroker/resolver.py
+++ b/proxybroker/resolver.py
@@ -183,7 +183,7 @@ class Resolver:
             return canonicalize_ip(host) or host
 
         _host = self._cached_hosts.get(host)
-        if _host:
+        if _host and self._cache_compatible(_host, family, qtype):
             return _host
 
         resp = await self._fetch_records(host, family, qtype)
@@ -214,6 +214,31 @@ class Resolver:
             if logging:
                 log.warning(f"{host}: Could not resolve host")
         return self._cached_hosts.get(host)
+
+    @staticmethod
+    def _cache_compatible(cached, family, qtype):
+        """Return True iff `cached` matches the caller's family/qtype intent.
+
+        The cache key is the bare hostname, so a prior default
+        Happy-Eyeballs lookup may have stored an IPv6 winner under
+        `host`. A subsequent caller pinning `family=AF_INET` or
+        `qtype="A"` must not silently receive that v6 — we validate
+        the cached IP's family before short-circuiting.
+        """
+        if family is None and qtype is _QTYPE_DEFAULT:
+            return True  # default path accepts whatever was cached
+        cached_ip = cached if isinstance(cached, str) else cached[0]["host"]
+        try:
+            cached_addr = ipaddress.ip_address(cached_ip)
+        except (ValueError, TypeError):
+            return False
+        wants_v4 = family == socket.AF_INET or qtype == "A"
+        wants_v6 = family == socket.AF_INET6 or qtype == "AAAA"
+        if wants_v4:
+            return isinstance(cached_addr, ipaddress.IPv4Address)
+        if wants_v6:
+            return isinstance(cached_addr, ipaddress.IPv6Address)
+        return True
 
     async def _fetch_records(self, host, family, qtype):
         """Choose A-only / AAAA-only / parallel race based on caller intent.

--- a/proxybroker/resolver.py
+++ b/proxybroker/resolver.py
@@ -149,12 +149,17 @@ class Resolver:
     async def resolve(self, host, port=80, family=None, qtype="A", logging=True):
         """Resolve `host` to one or more IP addresses.
 
-        `qtype` defaults to "A" for backwards compatibility. When the
-        caller doesn't request a specific record type and the A query
-        returns nothing, we transparently fall back to AAAA so that
-        IPv6-only hostnames (no A records) resolve too. This restores
-        end-to-end reachability for the increasing number of services
-        that publish AAAA-only records.
+        When the caller doesn't pin a specific record type (`qtype="A"`,
+        the default), A and AAAA queries fire in parallel per Happy
+        Eyeballs DNS (RFC 8305 § 3). The first non-empty answer wins;
+        the slower query is cancelled. If both fail, the most recent
+        error is re-raised to preserve the historical "could not
+        resolve" contract.
+
+        Sequential fallback would add a full DNS round-trip of latency
+        for v6-only hostnames; parallel race makes v4-only and v6-only
+        hosts resolve at roughly the same speed and shaves the worst-
+        case latency for dual-stack hosts on broken networks.
         """
         if self.host_is_ip(host):
             return host
@@ -163,23 +168,10 @@ class Resolver:
         if _host:
             return _host
 
-        # Transparent AAAA fallback for callers that didn't pin qtype.
-        # If A succeeds, use it. If A fails *and* the caller didn't pin
-        # qtype, try AAAA - so v6-only hostnames (no A record) resolve.
-        # If AAAA also fails, propagate ResolveError to preserve the
-        # original "could not resolve" contract.
-        try:
+        if qtype == "A":
+            resp = await self._race_a_aaaa(host)
+        else:
             resp = await self._resolve(host, qtype)
-        except ResolveError:
-            if qtype == "A":
-                resp = await self._resolve(host, "AAAA")
-            else:
-                raise
-        if not resp and qtype == "A":
-            try:
-                resp = await self._resolve(host, "AAAA")
-            except ResolveError:
-                resp = None
 
         if resp:
             hosts = [
@@ -203,6 +195,40 @@ class Resolver:
             if logging:
                 log.warning(f"{host}: Could not resolve host")
         return self._cached_hosts.get(host)
+
+    async def _race_a_aaaa(self, host):
+        """Race A and AAAA queries; return the first non-empty answer.
+
+        Implements Happy Eyeballs DNS (RFC 8305 § 3). Both queries are
+        scheduled concurrently. When the first one completes:
+          * Non-empty success: cancel the loser, return immediately.
+          * Empty result or `ResolveError`: keep waiting for the other.
+        If both fail, re-raise the most recent error so the surrounding
+        `resolve()` keeps its "could not resolve" contract intact.
+        """
+        a_task = asyncio.create_task(self._resolve(host, "A"))
+        aaaa_task = asyncio.create_task(self._resolve(host, "AAAA"))
+        pending = {a_task, aaaa_task}
+        last_error: Exception | None = None
+        try:
+            while pending:
+                done, pending = await asyncio.wait(
+                    pending, return_when=asyncio.FIRST_COMPLETED
+                )
+                for task in done:
+                    try:
+                        result = task.result()
+                    except ResolveError as exc:
+                        last_error = exc
+                        continue
+                    if result:
+                        return result
+        finally:
+            for task in pending:
+                task.cancel()
+        if last_error is not None:
+            raise last_error
+        return None
 
     async def _resolve(self, host, qtype):
         if self._resolver is None:

--- a/proxybroker/utils.py
+++ b/proxybroker/utils.py
@@ -44,7 +44,10 @@ IPPortPatternGlobal = re.compile(
 # hex/colon/dot/percent characters inside brackets) - validation is
 # performed by `canonicalize_ip` afterwards, not by the regex grammar.
 # Provably ReDoS-free (no alternation, no nested quantifiers).
-IPv6BracketedPortPattern = re.compile(r"\[([0-9A-Fa-f:.%]+)\]:(\d{2,5})")
+# Bracketed [v6]:port. Char class includes alphanumeric+`_`+`-` to
+# accept link-local zone IDs (e.g., `[fe80::1%eth0]:8080`); validation
+# done by `canonicalize_ip` afterwards, not the regex grammar.
+IPv6BracketedPortPattern = re.compile(r"\[([0-9A-Za-z:.%_\-]+)\]:(\d{2,5})")
 
 
 def get_headers(rv=False):
@@ -124,7 +127,11 @@ def get_all_ip(page: str) -> set[str]:
         if ":" not in tok:
             # Pure IPv4 token (no colon) - already covered by IPPattern.
             continue
-        canonical = canonicalize_ip(tok)
+        # Strip trailing punctuation that the tokenizer greedily includes
+        # (e.g., "Real IP: 2001:db8::1." would otherwise fail validation
+        # silently). Leading dots are not allowed by IPv6 grammar so no
+        # left strip needed.
+        canonical = canonicalize_ip(tok.rstrip("."))
         if canonical is not None:
             found.add(canonical)
     return found

--- a/proxybroker/utils.py
+++ b/proxybroker/utils.py
@@ -1,5 +1,6 @@
 """Utils."""
 
+import ipaddress
 import logging
 import os
 import os.path
@@ -18,13 +19,12 @@ IPPattern = re.compile(
     r"(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)"
 )
 
-# nosemgrep: python.lang.security.audit.regex_dos,app.packages.opengrep.rules.python.lang.security.audit.regex_dos
-# IPv6 grammar requires deep alternation. Inputs come from scraped pages
-# bounded to a few KB, not arbitrary user payloads, so the catastrophic-
-# backtracking risk is bounded. Replacing this would require reaching
-# for a non-stdlib parser - tracked for a future refactor.
-IPv6Pattern = re.compile(
-    r"\s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:)))(%.+)?\s*"
+# Narrow IPv6 candidate tokenizer: a run of hex/colon/dot/percent chars,
+# anchored to start at a hex digit or colon (so `::1` is matched). Zero
+# alternation, zero nesting - provably ReDoS-free. Validation is
+# delegated to stdlib `ipaddress.ip_address` instead of a regex grammar.
+_IPV6_CANDIDATE_PATTERN = re.compile(
+    r"[0-9A-Fa-f:][0-9A-Fa-f:.]*(?:%[A-Za-z0-9_.\-]+)?"
 )
 
 IPPortPatternLine = re.compile(
@@ -37,6 +37,14 @@ IPPortPatternGlobal = re.compile(
     r"(?=.*?(?:(?:(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?))|(?P<port>\d{2,5})))",  # noqa
     flags=re.DOTALL,
 )
+
+# Bracketed IPv6 + port: `[v6]:port`. RFC 3986 § 3.2.2 mandates this
+# form for IPv6 in URI authority components and most public proxy
+# feeds use it. The capture group is intentionally permissive (any
+# hex/colon/dot/percent characters inside brackets) - validation is
+# performed by `canonicalize_ip` afterwards, not by the regex grammar.
+# Provably ReDoS-free (no alternation, no nested quantifiers).
+IPv6BracketedPortPattern = re.compile(r"\[([0-9A-Fa-f:.%]+)\]:(\d{2,5})")
 
 
 def get_headers(rv=False):
@@ -56,9 +64,61 @@ def get_headers(rv=False):
     return headers if not rv else (headers, _rv)
 
 
+def canonicalize_ip(s):
+    """Return RFC 5952 canonical textual form of `s`, or None if invalid.
+
+    For IPv4 the canonical form equals the input (identity). For IPv6 the
+    canonical form is lowercase, leading zeros stripped, and the longest
+    zero-run replaced with `::`. Zone IDs (RFC 6874, e.g. `fe80::1%eth0`)
+    are preserved.
+
+    Adopt the canonical form whenever IP strings cross a boundary where
+    set-membership or substring comparison happens (e.g. anonymity-leak
+    detection). Two textually different but semantically equal addresses
+    must compare equal.
+    """
+    try:
+        return str(ipaddress.ip_address(s))
+    except (ValueError, TypeError):
+        return None
+
+
+def find_proxy_pairs(text):
+    """Extract `(ip, port)` proxy pairs from arbitrary text.
+
+    Returns a list of `(ip_canonical, port)` tuples. IPv4 entries use
+    the legacy `IPPortPatternGlobal` (so historical provider feeds parse
+    unchanged). IPv6 entries use the bracketed `[v6]:port` form per
+    RFC 3986; the v6 part is canonicalised via stdlib `ipaddress` and
+    bracketed garbage that doesn't validate is silently dropped.
+    """
+    pairs = list(IPPortPatternGlobal.findall(text))
+    for raw_v6, port in IPv6BracketedPortPattern.findall(text):
+        canonical = canonicalize_ip(raw_v6)
+        if canonical is not None:
+            pairs.append((canonical, port))
+    return pairs
+
+
 def get_all_ip(page):
-    # NOTE: IPv6 addresses support need to be tested
-    return set(IPPattern.findall(page) + IPv6Pattern.findall(page))
+    """Extract all IPv4 and IPv6 literals from `page`.
+
+    IPv4 addresses are extracted greedily as substrings (so
+    `"127.0.0.1"` is found inside `"127.0.0.1:80"`), preserving the
+    historical IPv4 contract. IPv6 candidates are validated by stdlib
+    `ipaddress.ip_address` and returned in RFC 5952 canonical form so
+    that different textual encodings of the same address (case,
+    leading zeros, `::` placement) collapse to one set element.
+    """
+    found = set(IPPattern.findall(page))
+    for tok in _IPV6_CANDIDATE_PATTERN.findall(page):
+        if ":" not in tok:
+            # Pure IPv4 token (no colon) - already covered by IPPattern.
+            continue
+        canonical = canonicalize_ip(tok)
+        if canonical is not None:
+            found.add(canonical)
+    return found
 
 
 def get_status_code(resp, start=9, stop=12):

--- a/proxybroker/utils.py
+++ b/proxybroker/utils.py
@@ -64,7 +64,7 @@ def get_headers(rv=False):
     return headers if not rv else (headers, _rv)
 
 
-def canonicalize_ip(s):
+def canonicalize_ip(s: str | None) -> str | None:
     """Return RFC 5952 canonical textual form of `s`, or None if invalid.
 
     For IPv4 the canonical form equals the input (identity). For IPv6 the
@@ -78,21 +78,30 @@ def canonicalize_ip(s):
     must compare equal.
     """
     try:
-        return str(ipaddress.ip_address(s))
+        return str(ipaddress.ip_address(s))  # type: ignore[arg-type]
     except (ValueError, TypeError):
         return None
 
 
-def find_proxy_pairs(text):
+def find_proxy_pairs(text: str) -> list[tuple[str, str]]:
     """Extract `(ip, port)` proxy pairs from arbitrary text.
 
-    Returns a list of `(ip_canonical, port)` tuples. IPv4 entries use
-    the legacy `IPPortPatternGlobal` (so historical provider feeds parse
-    unchanged). IPv6 entries use the bracketed `[v6]:port` form per
-    RFC 3986; the v6 part is canonicalised via stdlib `ipaddress` and
-    bracketed garbage that doesn't validate is silently dropped.
+    Returns a list of `(ip_canonical, port)` tuples. Both IPv4 and IPv6
+    are canonicalised via stdlib `ipaddress` so callers get one
+    consistent textual form regardless of how the source feed encoded
+    the address (case, leading zeros, `::` placement). IPv4 canonical
+    form equals the input, so legacy v4-only feeds see no behavior
+    change.
+
+    Bracketed v6 entries (`[v6]:port`, RFC 3986) and bare v4 entries
+    are both recognised. Invalid bracketed garbage is silently
+    dropped.
     """
-    pairs = list(IPPortPatternGlobal.findall(text))
+    pairs: list[tuple[str, str]] = []
+    for raw_v4, port in IPPortPatternGlobal.findall(text):
+        canonical = canonicalize_ip(raw_v4)
+        if canonical is not None:
+            pairs.append((canonical, port))
     for raw_v6, port in IPv6BracketedPortPattern.findall(text):
         canonical = canonicalize_ip(raw_v6)
         if canonical is not None:
@@ -100,7 +109,7 @@ def find_proxy_pairs(text):
     return pairs
 
 
-def get_all_ip(page):
+def get_all_ip(page: str) -> set[str]:
     """Extract all IPv4 and IPv6 literals from `page`.
 
     IPv4 addresses are extracted greedily as substrings (so
@@ -110,7 +119,7 @@ def get_all_ip(page):
     that different textual encodings of the same address (case,
     leading zeros, `::` placement) collapse to one set element.
     """
-    found = set(IPPattern.findall(page))
+    found: set[str] = set(IPPattern.findall(page))
     for tok in _IPV6_CANDIDATE_PATTERN.findall(page):
         if ":" not in tok:
             # Pure IPv4 token (no colon) - already covered by IPPattern.

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -118,6 +118,95 @@ class TestCheckerAPI:
         lvl = _get_anonymity_lvl(real_ip, mock_proxy, mock_judge, high_anon_content)
         assert lvl == "High"
 
+    def test_anonymity_level_ipv6_transparent(self):
+        """IPv6 leak detection must collapse equivalent textual forms.
+
+        The judge response can render the leaked IPv6 address in any
+        encoding (uppercase, expanded with leading zeros, with or
+        without `::` compression). Anonymity classification must
+        canonicalise both sides via stdlib `ipaddress` so equivalent
+        addresses compare equal.
+        """
+        from unittest.mock import Mock
+
+        from proxybroker.checker import _get_anonymity_lvl
+
+        real_ip = "2001:db8::1"  # canonical form
+        mock_proxy = Mock()
+        mock_proxy.log = Mock()
+        mock_judge = Mock()
+        mock_judge.marks = {"via": 0, "proxy": 0}
+
+        # Page leaks the same address in uppercase form -> Transparent.
+        uppercase_leak = "Your IP: 2001:DB8::1 (debug)"
+        assert (
+            _get_anonymity_lvl(real_ip, mock_proxy, mock_judge, uppercase_leak)
+            == "Transparent"
+        )
+
+        # Page leaks the same address in expanded form -> Transparent.
+        expanded_leak = "Your IP: 2001:0db8:0000:0000:0000:0000:0000:0001"
+        assert (
+            _get_anonymity_lvl(real_ip, mock_proxy, mock_judge, expanded_leak)
+            == "Transparent"
+        )
+
+    def test_ipv6_pipeline_smoke(self):
+        """End-to-end mock smoke: a v6-leaking judge response flows
+        through `_check_test_response` (sees the IP at all) AND
+        `_get_anonymity_lvl` (classifies as Transparent).
+
+        Exercises L1+L2+L3 together with no live v6 dependency.
+        """
+        from unittest.mock import Mock
+
+        from proxybroker.checker import _check_test_response, _get_anonymity_lvl
+        from proxybroker.utils import get_headers
+
+        real_ip = "2001:db8::1"  # canonical, as Resolver.get_real_ext_ip emits it
+        headers, rv = get_headers(rv=True)
+
+        # Judge response: code echoed, headers/cookies pass-through, real
+        # v6 leaked in expanded uppercase form (the worst-case scenario
+        # for a substring-only comparison).
+        leaked_content = (
+            f"Your code: {rv} "
+            f"Real IP: 2001:0DB8:0000:0000:0000:0000:0000:0001 "
+            f"Referer: {headers['Referer']} "
+            f"Cookie: {headers['Cookie']}"
+        )
+        mock_proxy = Mock()
+        mock_proxy.log = Mock()
+        mock_judge = Mock()
+        mock_judge.marks = {"via": 0, "proxy": 0}
+
+        # _check_test_response sees an IP -> True
+        assert _check_test_response(mock_proxy, headers, leaked_content, rv) is True
+
+        # _get_anonymity_lvl correctly identifies the v6 leak as Transparent
+        assert (
+            _get_anonymity_lvl(real_ip, mock_proxy, mock_judge, leaked_content)
+            == "Transparent"
+        )
+
+    def test_anonymity_level_ipv6_anonymous(self):
+        """IPv6 leak of a DIFFERENT address with proxy hint -> Anonymous."""
+        from unittest.mock import Mock
+
+        from proxybroker.checker import _get_anonymity_lvl
+
+        real_ip = "2001:db8::1"
+        mock_proxy = Mock()
+        mock_proxy.log = Mock()
+        mock_judge = Mock()
+        mock_judge.marks = {"via": 0, "proxy": 0}
+
+        # Different IPv6 address visible + via/proxy hint -> Anonymous.
+        content = '{"ip": "2001:db8::abcd", "via": "1.1 proxy"}'
+        assert (
+            _get_anonymity_lvl(real_ip, mock_proxy, mock_judge, content) == "Anonymous"
+        )
+
     def test_checker_response_validation_contract(self):
         """Test that response validation functions exist and work."""
         from unittest.mock import Mock

--- a/tests/test_negotiators.py
+++ b/tests/test_negotiators.py
@@ -91,6 +91,37 @@ class TestNegotiatorContracts:
             assert hasattr(negotiator, "negotiate")
 
 
+class TestConnectIPv6Authority:
+    """RFC 9112/9110 require IPv6 in URI authority + Host header to be
+    bracketed. Without brackets, `CONNECT 2001:db8::1:443` is ambiguous
+    and standards-compliant proxies will reject it.
+    """
+
+    def test_connect_request_ipv4_unbracketed(self):
+        from proxybroker.negotiators import _CONNECT_request
+
+        req = _CONNECT_request("198.51.100.1", 443).decode()
+        assert req.startswith("CONNECT 198.51.100.1:443 HTTP/1.1\r\n")
+        assert "\r\nHost: 198.51.100.1\r\n" in req
+
+    def test_connect_request_ipv6_brackets_authority_and_host(self):
+        from proxybroker.negotiators import _CONNECT_request
+
+        req = _CONNECT_request("2001:db8::1", 443).decode()
+        assert req.startswith("CONNECT [2001:db8::1]:443 HTTP/1.1\r\n")
+        assert "\r\nHost: [2001:db8::1]\r\n" in req
+
+    def test_connect_request_ipv6_bracket_25_443_80(self):
+        # All four CONNECT-using negotiators (CONNECT:80, CONNECT:25,
+        # HTTPS at 443, plus the SMTP variant) use _CONNECT_request, so
+        # this single helper test covers them all.
+        from proxybroker.negotiators import _CONNECT_request
+
+        for port in (80, 25, 443):
+            req = _CONNECT_request("fe80::abcd", port).decode()
+            assert f"CONNECT [fe80::abcd]:{port} HTTP/1.1\r\n" in req
+
+
 class TestSocks5IPv6Wire:
     """Wire-level tests for SOCKS5 ATYP encoding (RFC 1928).
 

--- a/tests/test_negotiators.py
+++ b/tests/test_negotiators.py
@@ -89,3 +89,98 @@ class TestNegotiatorContracts:
             negotiator = negotiator_class(mock_proxy)
             assert negotiator is not None
             assert hasattr(negotiator, "negotiate")
+
+
+class TestSocks5IPv6Wire:
+    """Wire-level tests for SOCKS5 ATYP encoding (RFC 1928).
+
+    SOCKS5 supports three address types:
+        ATYP=0x01  IPv4  (4 bytes)
+        ATYP=0x03  domain (1-byte length + name)
+        ATYP=0x04  IPv6  (16 bytes)
+
+    proxybroker historically only emitted ATYP=0x01 because the
+    upstream resolver returned IPv4-only and `inet_aton` enforced
+    that. With IPv6 enabled end-to-end, the negotiator MUST emit
+    ATYP=0x04 + 16-byte address for IPv6 destinations and continue
+    to emit ATYP=0x01 + 4-byte address for IPv4 (regression).
+    """
+
+    @pytest.mark.asyncio
+    async def test_socks5_ipv4_destination_emits_atyp_01_4_bytes(self):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from proxybroker.negotiators import Socks5Ngtr
+
+        mock_proxy = MagicMock()
+        mock_proxy.send = AsyncMock()
+        # Greeting reply (v5, no-auth) then connect-reply (v5, success, ATYP+addr+port).
+        connect_reply = bytes([0x05, 0x00, 0x00, 0x01]) + bytes(6)
+        mock_proxy.recv = AsyncMock(side_effect=[bytes([0x05, 0x00]), connect_reply])
+
+        ngtr = Socks5Ngtr(mock_proxy)
+        await ngtr.negotiate(ip="192.0.2.5", port=8080)
+
+        # Two send calls: greeting + connect-request.
+        assert mock_proxy.send.call_count == 2
+        connect_pkt = mock_proxy.send.call_args_list[1].args[0]
+        assert isinstance(connect_pkt, (bytes, bytearray))
+        # Total: VER(1)+CMD(1)+RSV(1)+ATYP(1)+IPv4(4)+PORT(2) = 10 bytes
+        assert len(connect_pkt) == 10
+        assert connect_pkt[0] == 0x05  # SOCKS version
+        assert connect_pkt[1] == 0x01  # CONNECT
+        assert connect_pkt[2] == 0x00  # RSV
+        assert connect_pkt[3] == 0x01  # ATYP=IPv4
+        # IPv4 packed
+        assert connect_pkt[4:8] == bytes([192, 0, 2, 5])
+        # Port big-endian
+        assert int.from_bytes(connect_pkt[8:10], "big") == 8080
+
+    @pytest.mark.asyncio
+    async def test_socks5_ipv6_destination_emits_atyp_04_16_bytes(self):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from proxybroker.negotiators import Socks5Ngtr
+
+        mock_proxy = MagicMock()
+        mock_proxy.send = AsyncMock()
+        # Greeting reply (v5, no-auth) then connect-reply (v5, success, ATYP=v6+addr+port).
+        connect_reply = bytes([0x05, 0x00, 0x00, 0x04]) + bytes(18)
+        mock_proxy.recv = AsyncMock(side_effect=[bytes([0x05, 0x00]), connect_reply])
+
+        ngtr = Socks5Ngtr(mock_proxy)
+        await ngtr.negotiate(ip="2001:db8::1", port=443)
+
+        connect_pkt = mock_proxy.send.call_args_list[1].args[0]
+        assert isinstance(connect_pkt, (bytes, bytearray))
+        # Total: VER(1)+CMD(1)+RSV(1)+ATYP(1)+IPv6(16)+PORT(2) = 22 bytes
+        assert len(connect_pkt) == 22
+        assert connect_pkt[0] == 0x05
+        assert connect_pkt[1] == 0x01
+        assert connect_pkt[2] == 0x00
+        assert connect_pkt[3] == 0x04  # ATYP=IPv6
+        # 2001:db8::1 packed = 32 bytes hex \x20\x01\x0d\xb8 ... \x00\x01
+        expected_packed = bytes.fromhex("20010db8000000000000000000000001")
+        assert connect_pkt[4:20] == expected_packed
+        assert int.from_bytes(connect_pkt[20:22], "big") == 443
+
+    def test_socks4_ipv6_raises_helpful_error(self):
+        """SOCKS4 RFC 1928 has no IPv6 address type. Asking for v6 over
+        SOCKS4 should fail loudly, not silently truncate or crash with a
+        cryptic struct error.
+        """
+        # The current implementation crashes with OSError from inet_aton.
+        # We document the current observable behavior here so we notice
+        # if it ever changes silently. A future tighter check could raise
+        # a domain-specific BadResponseError instead.
+        import asyncio
+        from unittest.mock import MagicMock
+
+        from proxybroker.negotiators import Socks4Ngtr
+
+        mock_proxy = MagicMock()
+        ngtr = Socks4Ngtr(mock_proxy)
+        with pytest.raises((OSError, ValueError)):
+            asyncio.get_event_loop().run_until_complete(
+                ngtr.negotiate(ip="2001:db8::1", port=443)
+            )

--- a/tests/test_negotiators.py
+++ b/tests/test_negotiators.py
@@ -121,6 +121,20 @@ class TestConnectIPv6Authority:
             req = _CONNECT_request("fe80::abcd", port).decode()
             assert f"CONNECT [fe80::abcd]:{port} HTTP/1.1\r\n" in req
 
+    def test_connect_request_does_not_double_bracket(self):
+        """If caller passes an already-bracketed v6 host (e.g. from
+        urlparse('https://[2001:db8::1]/').netloc), don't emit
+        `CONNECT [[2001:db8::1]]:443` which standards-compliant proxies
+        will reject.
+        """
+        from proxybroker.negotiators import _CONNECT_request
+
+        req = _CONNECT_request("[2001:db8::1]", 443).decode()
+        assert "CONNECT [2001:db8::1]:443 HTTP/1.1\r\n" in req
+        assert "[[" not in req
+        assert "]]" not in req
+        assert "\r\nHost: [2001:db8::1]\r\n" in req
+
 
 class TestSocks5IPv6Wire:
     """Wire-level tests for SOCKS5 ATYP encoding (RFC 1928).

--- a/tests/test_negotiators.py
+++ b/tests/test_negotiators.py
@@ -195,23 +195,19 @@ class TestSocks5IPv6Wire:
         assert connect_pkt[4:20] == expected_packed
         assert int.from_bytes(connect_pkt[20:22], "big") == 443
 
-    def test_socks4_ipv6_raises_helpful_error(self):
-        """SOCKS4 RFC 1928 has no IPv6 address type. Asking for v6 over
-        SOCKS4 should fail loudly, not silently truncate or crash with a
-        cryptic struct error.
+    @pytest.mark.asyncio
+    async def test_socks4_ipv6_raises_bad_response_with_clear_message(self):
+        """SOCKS4 has no v6 address type. Callers asking for v6 get a
+        domain-specific BadResponseError pointing them to SOCKS5 - not
+        a cryptic OSError from inet_aton.
         """
-        # The current implementation crashes with OSError from inet_aton.
-        # We document the current observable behavior here so we notice
-        # if it ever changes silently. A future tighter check could raise
-        # a domain-specific BadResponseError instead.
-        import asyncio
         from unittest.mock import MagicMock
 
+        from proxybroker.errors import BadResponseError
         from proxybroker.negotiators import Socks4Ngtr
 
         mock_proxy = MagicMock()
         ngtr = Socks4Ngtr(mock_proxy)
-        with pytest.raises((OSError, ValueError)):
-            asyncio.get_event_loop().run_until_complete(
-                ngtr.negotiate(ip="2001:db8::1", port=443)
-            )
+        with pytest.raises(BadResponseError) as exc_info:
+            await ngtr.negotiate(ip="2001:db8::1", port=443)
+        assert "IPv6" in str(exc_info.value)

--- a/tests/test_negotiators.py
+++ b/tests/test_negotiators.py
@@ -138,6 +138,36 @@ class TestSocks5IPv6Wire:
     """
 
     @pytest.mark.asyncio
+    async def test_socks5_dual_stack_proxy_returns_v6_bnd_for_v4_request(self):
+        """RFC 1928 § 6: BND.ADDR can be a different family than the
+        client requested (dual-stack proxy may bind v6 even for a v4
+        request). Negotiator must parse reply ATYP from the response,
+        not assume it matches the request.
+        """
+        from unittest.mock import AsyncMock, MagicMock
+
+        from proxybroker.negotiators import Socks5Ngtr
+
+        mock_proxy = MagicMock()
+        mock_proxy.send = AsyncMock()
+        mock_proxy.recv = AsyncMock(
+            side_effect=[
+                bytes([0x05, 0x00]),
+                # Client requested v4 dest, but proxy bound v6 → ATYP=0x04.
+                # Old code that derived reply_size from the *request* atyp
+                # would under-read by 12 bytes and stall.
+                bytes([0x05, 0x00, 0x00, 0x04]),
+                bytes(18),
+            ]
+        )
+
+        ngtr = Socks5Ngtr(mock_proxy)
+        await ngtr.negotiate(ip="192.0.2.5", port=8080)
+        # Three recvs: greeting, header, body. The negotiator correctly
+        # noticed the response was v6 even though the request was v4.
+        assert mock_proxy.recv.call_count == 3
+
+    @pytest.mark.asyncio
     async def test_socks5_ipv4_destination_emits_atyp_01_4_bytes(self):
         from unittest.mock import AsyncMock, MagicMock
 
@@ -145,9 +175,16 @@ class TestSocks5IPv6Wire:
 
         mock_proxy = MagicMock()
         mock_proxy.send = AsyncMock()
-        # Greeting reply (v5, no-auth) then connect-reply (v5, success, ATYP+addr+port).
-        connect_reply = bytes([0x05, 0x00, 0x00, 0x01]) + bytes(6)
-        mock_proxy.recv = AsyncMock(side_effect=[bytes([0x05, 0x00]), connect_reply])
+        # Three recv calls: greeting reply, fixed 4-byte connect-reply
+        # header (VER+REP+RSV+ATYP), then variable BND.ADDR+BND.PORT.
+        # Negotiator parses ATYP from the response, not the request.
+        mock_proxy.recv = AsyncMock(
+            side_effect=[
+                bytes([0x05, 0x00]),  # greeting reply
+                bytes([0x05, 0x00, 0x00, 0x01]),  # connect-reply header (v4 BND)
+                bytes(6),  # 4-byte v4 BND.ADDR + 2-byte BND.PORT
+            ]
+        )
 
         ngtr = Socks5Ngtr(mock_proxy)
         await ngtr.negotiate(ip="192.0.2.5", port=8080)
@@ -175,9 +212,17 @@ class TestSocks5IPv6Wire:
 
         mock_proxy = MagicMock()
         mock_proxy.send = AsyncMock()
-        # Greeting reply (v5, no-auth) then connect-reply (v5, success, ATYP=v6+addr+port).
-        connect_reply = bytes([0x05, 0x00, 0x00, 0x04]) + bytes(18)
-        mock_proxy.recv = AsyncMock(side_effect=[bytes([0x05, 0x00]), connect_reply])
+        # Three recv calls: greeting reply, fixed 4-byte connect-reply
+        # header with ATYP=0x04 (v6), then 16-byte BND.ADDR + 2-byte
+        # BND.PORT. Confirms the negotiator reads in two stages and
+        # picks reply_size from the response ATYP, not the request ATYP.
+        mock_proxy.recv = AsyncMock(
+            side_effect=[
+                bytes([0x05, 0x00]),  # greeting reply
+                bytes([0x05, 0x00, 0x00, 0x04]),  # connect-reply header (v6 BND)
+                bytes(18),  # 16-byte v6 BND.ADDR + 2-byte BND.PORT
+            ]
+        )
 
         ngtr = Socks5Ngtr(mock_proxy)
         await ngtr.negotiate(ip="2001:db8::1", port=443)

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -96,6 +96,31 @@ class TestProviderFindProxies:
         p = Provider(url="http://example.com")
         assert p.find_proxies("just some prose without any proxies") == []
 
+    def test_ipv6_mapped_does_not_spawn_phantom_ipv4(self):
+        """IPv4-mapped IPv6 entries like `[::ffff:192.0.2.1]:8080` must
+        produce ONLY the v6 entry — not also a phantom `192.0.2.1:8080`
+        from the legacy IPv4 regex matching the embedded v4 octets.
+
+        Provider feeds in the wild occasionally emit v4-mapped form;
+        without masking the bracketed span before the v4 pass, every
+        such proxy spawns an additional invalid v4 endpoint that the
+        provider never advertised.
+        """
+        p = Provider(url="http://example.com")
+        page = "real proxy: [::ffff:192.0.2.1]:8080 trailer"
+        results = p.find_proxies(page)
+        assert ("::ffff:192.0.2.1", "8080") in results
+        assert not any(host == "192.0.2.1" for host, _port in results)
+
+    def test_ipv6_bracketed_alongside_v4_pairs(self):
+        """Mixed v4/v6 page: both forms extracted, no cross-pollination."""
+        p = Provider(url="http://example.com")
+        page = "v4: 192.0.2.5:3128 v6: [2001:db8::1]:9090 more v4: 198.51.100.10:8080"
+        results = p.find_proxies(page)
+        assert ("192.0.2.5", "3128") in results
+        assert ("198.51.100.10", "8080") in results
+        assert ("2001:db8::1", "9090") in results
+
 
 @pytest.mark.asyncio
 async def test_find_on_pages_handles_empty_url_list():

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -10,7 +10,7 @@ from proxybroker.errors import ProxyConnError, ProxyTimeoutError, ResolveError
 from proxybroker.negotiators import HttpsNgtr
 from proxybroker.utils import log as logger
 
-from .utils import ResolveResult, future_iter
+from .utils import ResolveResult
 
 
 def test_ssl_context_unverified_by_default():

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -31,6 +31,46 @@ def test_ssl_context_verified_when_requested():
     assert p._ssl_context is True
 
 
+def test_proxy_accepts_ipv6_host_literal():
+    """Proxy(host=v6) must construct without raising.
+
+    Relies on Resolver.host_is_ip accepting v6 literals (L1).
+    Geo-info lookup tolerates absent v6 ranges in the bundled
+    GeoLite2 DB and falls back to "Unknown".
+    """
+    p = Proxy("2001:db8::1", "8080")
+    assert p.host == "2001:db8::1"
+    assert p.port == 8080
+
+
+def test_proxy_rejects_v6_with_brackets():
+    """Brackets are URI authority syntax (RFC 3986), not the literal
+    host - must NOT be accepted as a Proxy host. Caller should strip
+    brackets before constructing.
+    """
+    with pytest.raises(ValueError):
+        Proxy("[2001:db8::1]", "8080")
+
+
+def test_proxy_as_text_brackets_v6():
+    """as_text emits standard host:port form. For IPv6 hosts, RFC 3986
+    requires brackets so the colon doesn't ambiguate against the port.
+    """
+    v4 = Proxy("127.0.0.1", "80")
+    assert v4.as_text() == "127.0.0.1:80\n"
+
+    v6 = Proxy("2001:db8::1", "8080")
+    assert v6.as_text() == "[2001:db8::1]:8080\n"
+
+
+def test_proxy_repr_brackets_v6():
+    """repr() of a v6-host proxy must bracket the host so logs are
+    unambiguous.
+    """
+    p = Proxy("2001:db8::1", "8080")
+    assert "[2001:db8::1]:8080" in repr(p)
+
+
 @pytest.fixture
 async def proxy():
     # async fixture so pytest-asyncio sets up an event loop first.

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,3 +1,4 @@
+import asyncio
 import ssl
 import time
 from asyncio.streams import StreamReader
@@ -92,11 +93,20 @@ async def test_create_by_ip():
 
 @pytest.mark.asyncio
 async def test_create_by_domain(mocker):
-    f = future_iter([ResolveResult("127.0.0.1", 0)])
-    # pytest-mock teardonw is done when existing thr fixture object
-    # no need context manager
-    # https://github.com/pytest-dev/pytest-mock#note-about-usage-as-context-manager
-    mocker.patch("aiodns.DNSResolver.query", side_effect=f)
+    # Resolver.resolve() races A and AAAA in parallel (Happy Eyeballs DNS,
+    # RFC 8305 § 3). Mock provides a v4 record for A and explicitly fails
+    # AAAA so the v4 result wins deterministically.
+    import aiodns
+
+    a_future = asyncio.Future()
+    a_future.set_result([ResolveResult("127.0.0.1", 0)])
+
+    def query_side_effect(host, qtype):
+        if qtype == "A":
+            return a_future
+        raise aiodns.error.DNSError(1, "no AAAA record (test)")
+
+    mocker.patch("aiodns.DNSResolver.query", side_effect=query_side_effect)
     proxy = await Proxy.create("testhost.com", "80")
     assert proxy.host == "127.0.0.1"
 

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -20,6 +20,33 @@ def test_host_is_ip(resolver):
     assert resolver.host_is_ip("test.com") is False
 
 
+def test_host_is_ip_ipv6(resolver):
+    # IPv6 loopback, documentation prefix, IPv4-mapped, zone IDs.
+    assert resolver.host_is_ip("::1") is True
+    assert resolver.host_is_ip("2001:db8::1") is True
+    assert resolver.host_is_ip("2001:DB8::1") is True
+    assert resolver.host_is_ip("::ffff:192.0.2.1") is True
+    assert resolver.host_is_ip("fe80::1%eth0") is True
+
+
+def test_host_is_ip_rejects_garbage(resolver):
+    assert resolver.host_is_ip("not-an-ip") is False
+    assert resolver.host_is_ip("dead.beef.cafe") is False
+    assert resolver.host_is_ip(":::") is False
+    assert resolver.host_is_ip("") is False
+
+
+def test_host_is_ip_rejects_url_or_host_with_path(resolver):
+    # Defensive: things that look IP-ish but include extra characters
+    # (port, path, brackets) must not pass `is this an IP literal`.
+    assert resolver.host_is_ip("127.0.0.1:80") is False
+    assert resolver.host_is_ip("[2001:db8::1]") is False
+    assert (
+        resolver.host_is_ip("2001:db8::1:8080") is True
+    )  # last group "8080" — still a valid v6 by parser
+    assert resolver.host_is_ip("http://1.2.3.4") is False
+
+
 def test_get_ip_info(resolver):
     ip = resolver.get_ip_info("127.0.0.1")
     assert ip.code == "--"
@@ -37,6 +64,37 @@ async def test_get_real_ext_ip(event_loop, mocker, resolver):
     # Just mock the method itself to avoid complex aiohttp mocking
     mocker.patch.object(resolver, "get_real_ext_ip", return_value="127.0.0.1")
     assert await resolver.get_real_ext_ip() == "127.0.0.1"
+
+
+@pytest.mark.asyncio
+async def test_get_real_ext_ip_canonicalises_ipv6(mocker):
+    """get_real_ext_ip must return RFC 5952 canonical form.
+
+    Regardless of how the upstream IP-detection service emits the
+    address, downstream comparison sites rely on canonical form for
+    correctness. Verifies via fully-faked aiohttp.ClientSession.
+    """
+    from contextlib import asynccontextmanager
+    from unittest.mock import AsyncMock, MagicMock
+
+    resolver_inst = Resolver(timeout=1)
+
+    fake_resp = MagicMock()
+    fake_resp.text = AsyncMock(return_value="2001:DB8::1\n")
+
+    @asynccontextmanager
+    async def fake_get(_url):
+        yield fake_resp
+
+    @asynccontextmanager
+    async def fake_session(*_args, **_kwargs):
+        sess = MagicMock()
+        sess.get = fake_get
+        yield sess
+
+    mocker.patch("proxybroker.resolver.aiohttp.ClientSession", fake_session)
+
+    assert await resolver_inst.get_real_ext_ip() == "2001:db8::1"
 
 
 @pytest.mark.asyncio

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -185,6 +185,47 @@ async def test_resolve_happy_eyeballs_v6_only_when_a_fails(mocker, resolver):
 
 
 @pytest.mark.asyncio
+async def test_resolve_explicit_qtype_a_does_not_race(mocker, resolver):
+    """Caller passing qtype='A' explicitly gets legacy A-only path - no
+    AAAA query, no race. Without this, a caller that needs A-only
+    semantics could get an IPv6 answer back if AAAA wins the race,
+    breaking their downstream contract.
+    """
+    resolver._cached_hosts.clear()
+    from types import SimpleNamespace
+
+    calls = []
+
+    async def fake_resolve(host, qtype):
+        calls.append(qtype)
+        return [SimpleNamespace(host="192.0.2.10")]
+
+    mocker.patch.object(resolver, "_resolve", side_effect=fake_resolve)
+    result = await resolver.resolve("a-only.example.com", qtype="A")
+    assert calls == ["A"]
+    assert result == "192.0.2.10"
+
+
+@pytest.mark.asyncio
+async def test_resolve_explicit_family_inet_does_not_race(mocker, resolver):
+    """Caller passing family=AF_INET expects only A records back. The
+    sentinel-default qtype lets us distinguish this from the racing path.
+    """
+    resolver._cached_hosts.clear()
+    from types import SimpleNamespace
+
+    calls = []
+
+    async def fake_resolve(host, qtype):
+        calls.append(qtype)
+        return [SimpleNamespace(host="192.0.2.20")]
+
+    mocker.patch.object(resolver, "_resolve", side_effect=fake_resolve)
+    await resolver.resolve("v4-only.example.com", family=socket.AF_INET)
+    assert calls == ["A"]
+
+
+@pytest.mark.asyncio
 async def test_resolve_happy_eyeballs_both_fail_raises(mocker, resolver):
     """If both A and AAAA fail, ResolveError propagates (preserves the
     legacy "could not resolve" contract that callers rely on)."""
@@ -264,17 +305,17 @@ async def test_resolve_cache(mocker, resolver):
     mocker.patch("aiodns.DNSResolver.query", side_effect=query_side_effect)
     await resolver.resolve("test.com")
     await resolver.resolve("test2.com", port=80, family=socket.AF_INET)
-    # Happy Eyeballs DNS fires both A and AAAA per resolve() call, so
-    # 2 fresh resolves => 4 underlying _resolve invocations (A + AAAA
-    # for each host). The AAAA half raises (per query_side_effect) and
-    # is gracefully discarded by _race_a_aaaa.
-    assert resolver._resolve.call_count == 4
+    # Resolve dispatch:
+    #   resolve("test.com") - no family pinned -> Happy Eyeballs (2 calls)
+    #   resolve("test2.com", family=AF_INET) - family pinned -> A-only (1 call)
+    # = 3 _resolve invocations.
+    assert resolver._resolve.call_count == 3
 
     assert await resolver.resolve("test.com") == "127.0.0.1"
     resp = await resolver.resolve("test2.com")
     assert resp[0]["host"] == "127.0.0.2"
-    # Cache hits short-circuit before _race_a_aaaa, so no new calls.
-    assert resolver._resolve.call_count == 4
+    # Cache hits short-circuit before any _resolve call.
+    assert resolver._resolve.call_count == 3
 
     # Mock an exception for test3.com
     mocker.patch(
@@ -283,6 +324,6 @@ async def test_resolve_cache(mocker, resolver):
     )
     with pytest.raises(ResolveError):
         await resolver.resolve("test3.com")
-    # Failed resolve still fires both A and AAAA in parallel; both
-    # raise -> 2 additional _resolve invocations.
-    assert resolver._resolve.call_count == 6
+    # No family pinned -> Happy Eyeballs race; both A and AAAA fail -> 2
+    # additional _resolve invocations -> 5 total.
+    assert resolver._resolve.call_count == 5

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -327,3 +327,37 @@ async def test_resolve_cache(mocker, resolver):
     # No family pinned -> Happy Eyeballs race; both A and AAAA fail -> 2
     # additional _resolve invocations -> 5 total.
     assert resolver._resolve.call_count == 5
+
+
+@pytest.mark.asyncio
+async def test_resolve_cache_rejects_v6_for_a_only_callers(mocker, resolver):
+    """A prior default Happy-Eyeballs lookup may have cached an IPv6
+    winner for `host`. A later caller pinning `family=AF_INET` or
+    `qtype="A"` must NOT silently get that v6 back from the cache.
+
+    The fix: `_cache_compatible(cached, family, qtype)` validates the
+    cached IP against the requested family before short-circuiting.
+    """
+    # Pre-populate the cache as if a default lookup found IPv6.
+    resolver._cached_hosts.clear()
+    resolver._cached_hosts["dual.example.com"] = "2001:db8::1"
+
+    a_only_records = [ResolveResult("192.0.2.5", 0)]
+
+    async def fake_resolve(host, qtype):
+        if qtype == "A" and host == "dual.example.com":
+            return a_only_records
+        from aiodns.error import DNSError
+
+        raise DNSError(1, f"no {qtype} for {host} (test)")
+
+    mocker.patch.object(resolver, "_resolve", side_effect=fake_resolve)
+
+    # family=AF_INET -> cache should reject the v6 entry and do fresh lookup
+    resp = await resolver.resolve("dual.example.com", port=80, family=socket.AF_INET)
+    assert resp[0]["host"] == "192.0.2.5"
+
+    # Default unpinned lookup still returns the cached v6 (any-family path).
+    # Reset spy so we count from clean state.
+    resolver._cached_hosts["dual.example.com"] = "2001:db8::1"
+    assert await resolver.resolve("dual.example.com") == "2001:db8::1"

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -252,12 +252,17 @@ async def test_resolve_cache(event_loop, mocker, resolver):
     mocker.patch("aiodns.DNSResolver.query", side_effect=query_side_effect)
     await resolver.resolve("test.com")
     await resolver.resolve("test2.com", port=80, family=socket.AF_INET)
-    assert resolver._resolve.call_count == 2
+    # Happy Eyeballs DNS fires both A and AAAA per resolve() call, so
+    # 2 fresh resolves => 4 underlying _resolve invocations (A + AAAA
+    # for each host). The AAAA half raises (per query_side_effect) and
+    # is gracefully discarded by _race_a_aaaa.
+    assert resolver._resolve.call_count == 4
 
     assert await resolver.resolve("test.com") == "127.0.0.1"
     resp = await resolver.resolve("test2.com")
     assert resp[0]["host"] == "127.0.0.2"
-    assert resolver._resolve.call_count == 2
+    # Cache hits short-circuit before _race_a_aaaa, so no new calls.
+    assert resolver._resolve.call_count == 4
 
     # Mock an exception for test3.com
     mocker.patch(
@@ -266,4 +271,6 @@ async def test_resolve_cache(event_loop, mocker, resolver):
     )
     with pytest.raises(ResolveError):
         await resolver.resolve("test3.com")
-    assert resolver._resolve.call_count == 3
+    # Failed resolve still fires both A and AAAA in parallel; both
+    # raise -> 2 additional _resolve invocations.
+    assert resolver._resolve.call_count == 6

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -230,11 +230,26 @@ async def test_resolve_cache(event_loop, mocker, resolver):
     assert resolver._resolve.call_count == 0
 
     resolver._cached_hosts.clear()
-    f = future_iter(
-        [ResolveResult("127.0.0.1", 0)],
-        [ResolveResult("127.0.0.2", 0)],
-    )
-    mocker.patch("aiodns.DNSResolver.query", side_effect=f)
+    # Resolver.resolve() races A+AAAA in parallel (Happy Eyeballs DNS,
+    # RFC 8305 § 3) when the caller doesn't pin qtype. Each resolve()
+    # call fires both queries; AAAA raises here so v4 wins
+    # deterministically per host. _resolve is still called twice (once
+    # per resolve() call - the helper doesn't double-count internally).
+    import aiodns
+
+    a_futures = {
+        "test.com": [ResolveResult("127.0.0.1", 0)],
+        "test2.com": [ResolveResult("127.0.0.2", 0)],
+    }
+
+    def query_side_effect(host, qtype):
+        if qtype == "A" and host in a_futures:
+            f = asyncio.Future()
+            f.set_result(a_futures[host])
+            return f
+        raise aiodns.error.DNSError(1, f"no {qtype} record for {host} (test)")
+
+    mocker.patch("aiodns.DNSResolver.query", side_effect=query_side_effect)
     await resolver.resolve("test.com")
     await resolver.resolve("test2.com", port=80, family=socket.AF_INET)
     assert resolver._resolve.call_count == 2

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -6,7 +6,7 @@ import pytest
 from proxybroker.errors import ResolveError
 from proxybroker.resolver import Resolver
 
-from .utils import ResolveResult, future_iter
+from .utils import ResolveResult
 
 
 @pytest.fixture
@@ -104,9 +104,21 @@ async def test_resolve(event_loop, mocker, resolver):
     with pytest.raises(ResolveError):
         await resolver.resolve("256.0.0.1")
 
-    f = future_iter([ResolveResult("127.0.0.1", 0)])
-    # https://github.com/pytest-dev/pytest-mock#note-about-usage-as-context-manager
-    mocker.patch("aiodns.DNSResolver.query", side_effect=f)
+    # Resolver.resolve() races A+AAAA in parallel (Happy Eyeballs DNS).
+    # Mock provides v4 record for A queries; AAAA raises so v4 wins
+    # deterministically. Without this, future_iter([single_result])
+    # gets exhausted on the second call and surfaces as StopIteration.
+    import aiodns
+
+    a_future = asyncio.Future()
+    a_future.set_result([ResolveResult("127.0.0.1", 0)])
+
+    def query_side_effect(host, qtype):
+        if qtype == "A":
+            return a_future
+        raise aiodns.error.DNSError(1, "no AAAA record (test)")
+
+    mocker.patch("aiodns.DNSResolver.query", side_effect=query_side_effect)
     assert await resolver.resolve("test.com") == "127.0.0.1"
 
 

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -60,7 +60,7 @@ def test_get_ip_info(resolver):
 
 
 @pytest.mark.asyncio
-async def test_get_real_ext_ip(event_loop, mocker, resolver):
+async def test_get_real_ext_ip(mocker, resolver):
     # Just mock the method itself to avoid complex aiohttp mocking
     mocker.patch.object(resolver, "get_real_ext_ip", return_value="127.0.0.1")
     assert await resolver.get_real_ext_ip() == "127.0.0.1"
@@ -98,7 +98,7 @@ async def test_get_real_ext_ip_canonicalises_ipv6(mocker):
 
 
 @pytest.mark.asyncio
-async def test_resolve(event_loop, mocker, resolver):
+async def test_resolve(mocker, resolver):
     assert await resolver.resolve("127.0.0.1") == "127.0.0.1"
 
     with pytest.raises(ResolveError):
@@ -233,7 +233,7 @@ async def test_resolve_family(mocker, resolver):
 
 
 @pytest.mark.asyncio
-async def test_resolve_cache(event_loop, mocker, resolver):
+async def test_resolve_cache(mocker, resolver):
     # Pre-populate cache to test cache hit behavior
     resolver._cached_hosts["test.com"] = "127.0.0.1"
 

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -111,36 +111,101 @@ async def test_resolve(event_loop, mocker, resolver):
 
 
 @pytest.mark.asyncio
-async def test_resolve_falls_back_to_aaaa_for_v6_only_host(mocker, resolver):
-    """When A query returns no records, resolve() must transparently
-    fall back to AAAA so v6-only hostnames (no A record) still resolve.
-    Without this, judges and proxy hosts with AAAA-only DNS silently
-    fail to be reachable.
-    """
-    from proxybroker.errors import ResolveError
+async def test_resolve_happy_eyeballs_v6_wins_when_faster(mocker, resolver):
+    """RFC 8305 § 3: A and AAAA fire in parallel; the faster one wins."""
+    resolver._cached_hosts.clear()
 
-    a_calls = []
+    from types import SimpleNamespace
+
+    calls = []
 
     async def fake_resolve(host, qtype):
-        a_calls.append(qtype)
+        calls.append(qtype)
+        if qtype == "AAAA":
+            await asyncio.sleep(0.001)  # faster
+            return [SimpleNamespace(host="2001:db8::5")]
+        await asyncio.sleep(0.05)  # slower
+        return [SimpleNamespace(host="192.0.2.5")]
+
+    mocker.patch.object(resolver, "_resolve", side_effect=fake_resolve)
+    result = await resolver.resolve("dual-v6-wins.example.com")
+    # Both queries fired in parallel
+    assert set(calls) == {"A", "AAAA"}
+    assert result == "2001:db8::5"
+
+
+@pytest.mark.asyncio
+async def test_resolve_happy_eyeballs_v4_wins_when_faster(mocker, resolver):
+    # `_cached_hosts` is a class attribute; clear it so any prior test
+    # that resolved the same hostname doesn't return a stale entry
+    # before our mock fires.
+    resolver._cached_hosts.clear()
+
+    from types import SimpleNamespace
+
+    async def fake_resolve(host, qtype):
+        if qtype == "A":
+            await asyncio.sleep(0.001)
+            return [SimpleNamespace(host="192.0.2.5")]
+        await asyncio.sleep(0.05)
+        return [SimpleNamespace(host="2001:db8::5")]
+
+    mocker.patch.object(resolver, "_resolve", side_effect=fake_resolve)
+    assert await resolver.resolve("dual-v4-wins.example.com") == "192.0.2.5"
+
+
+@pytest.mark.asyncio
+async def test_resolve_happy_eyeballs_v6_only_when_a_fails(mocker, resolver):
+    """v6-only hostnames (no A record) still resolve when A raises."""
+    resolver._cached_hosts.clear()
+
+    from types import SimpleNamespace
+
+    from proxybroker.errors import ResolveError
+
+    async def fake_resolve(host, qtype):
         if qtype == "A":
             raise ResolveError
-        # AAAA: return a fake aiodns-style record with .host
-        from types import SimpleNamespace
-
         return [SimpleNamespace(host="2001:db8::abcd")]
 
     mocker.patch.object(resolver, "_resolve", side_effect=fake_resolve)
-    result = await resolver.resolve("v6only.example.com")
-    assert a_calls == ["A", "AAAA"]
-    assert result == "2001:db8::abcd"
+    assert await resolver.resolve("v6only.example.com") == "2001:db8::abcd"
+
+
+@pytest.mark.asyncio
+async def test_resolve_happy_eyeballs_both_fail_raises(mocker, resolver):
+    """If both A and AAAA fail, ResolveError propagates (preserves the
+    legacy "could not resolve" contract that callers rely on)."""
+    resolver._cached_hosts.clear()
+
+    from proxybroker.errors import ResolveError
+
+    async def fake_resolve(host, qtype):
+        raise ResolveError
+
+    mocker.patch.object(resolver, "_resolve", side_effect=fake_resolve)
+    with pytest.raises(ResolveError):
+        await resolver.resolve("nonexistent.example.com")
 
 
 @pytest.mark.asyncio
 async def test_resolve_family(mocker, resolver):
-    f = future_iter([ResolveResult("127.0.0.2", 0)])
-    # https://github.com/pytest-dev/pytest-mock#note-about-usage-as-context-manager
-    mocker.patch("aiodns.DNSResolver.query", side_effect=f)
+    # Resolver.resolve() races A+AAAA in parallel (Happy Eyeballs DNS,
+    # RFC 8305 § 3) when the caller doesn't pin qtype. This mock lets
+    # the A query win deterministically by making AAAA raise so only
+    # the v4 record is returned, matching the test's intent
+    # (family=AF_INET expects a v4 record).
+    import aiodns
+
+    a_future = asyncio.Future()
+    a_future.set_result([ResolveResult("127.0.0.2", 0)])
+
+    def query_side_effect(host, qtype):
+        if qtype == "A":
+            return a_future
+        raise aiodns.error.DNSError(1, "no AAAA record (test)")
+
+    mocker.patch("aiodns.DNSResolver.query", side_effect=query_side_effect)
     resp = [
         {
             "hostname": "test2.com",

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -111,6 +111,32 @@ async def test_resolve(event_loop, mocker, resolver):
 
 
 @pytest.mark.asyncio
+async def test_resolve_falls_back_to_aaaa_for_v6_only_host(mocker, resolver):
+    """When A query returns no records, resolve() must transparently
+    fall back to AAAA so v6-only hostnames (no A record) still resolve.
+    Without this, judges and proxy hosts with AAAA-only DNS silently
+    fail to be reachable.
+    """
+    from proxybroker.errors import ResolveError
+
+    a_calls = []
+
+    async def fake_resolve(host, qtype):
+        a_calls.append(qtype)
+        if qtype == "A":
+            raise ResolveError
+        # AAAA: return a fake aiodns-style record with .host
+        from types import SimpleNamespace
+
+        return [SimpleNamespace(host="2001:db8::abcd")]
+
+    mocker.patch.object(resolver, "_resolve", side_effect=fake_resolve)
+    result = await resolver.resolve("v6only.example.com")
+    assert a_calls == ["A", "AAAA"]
+    assert result == "2001:db8::abcd"
+
+
+@pytest.mark.asyncio
 async def test_resolve_family(mocker, resolver):
     f = future_iter([ResolveResult("127.0.0.2", 0)])
     # https://github.com/pytest-dev/pytest-mock#note-about-usage-as-context-manager

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,7 @@ import pytest
 
 from proxybroker.errors import BadStatusLine
 from proxybroker.utils import (
+    canonicalize_ip,
     get_all_ip,
     get_status_code,
     parse_headers,
@@ -12,6 +13,139 @@ from proxybroker.utils import (
 def test_get_all_ip():
     page = "abc127.0.0.1:80abc127.0.0.1xx127.0.0.2:8080h"
     assert get_all_ip(page) == {"127.0.0.1", "127.0.0.2"}
+
+
+def test_get_all_ip_ipv6_loopback():
+    assert "::1" in get_all_ip("real ip is ::1 leak")
+
+
+def test_get_all_ip_ipv6_documentation_range():
+    # RFC 3849 documentation prefix; canonical lowercase per RFC 5952.
+    assert "2001:db8::1" in get_all_ip("server: 2001:DB8::1 here")
+
+
+def test_get_all_ip_ipv6_ipv4_mapped():
+    found = get_all_ip("transparent: ::ffff:192.0.2.1 leak")
+    # IPv4-mapped form preserved as-is by stdlib canonicalisation.
+    assert "::ffff:192.0.2.1" in found
+    # The embedded v4 part should also be picked up by the v4 path.
+    assert "192.0.2.1" in found
+
+
+def test_get_all_ip_ipv6_with_zone_id():
+    # Link-local addresses include zone IDs (RFC 6874).
+    assert "fe80::1%eth0" in get_all_ip("link-local fe80::1%eth0 trailing")
+
+
+def test_get_all_ip_ipv6_with_port_brackets():
+    # Bracketed [v6]:port form is the standard textual notation;
+    # the v6 part inside the brackets must still be extracted.
+    assert "2001:db8::1" in get_all_ip("contact [2001:db8::1]:8080 here")
+
+
+def test_get_all_ip_rejects_malformed_ipv4():
+    # Out-of-range octets must NOT appear in the set. Note: the existing
+    # IPv4 regex over-matches "999.999.999.999" as substrings of valid
+    # octets ("99.99.99.99"), so we assert the malformed form is absent
+    # rather than asserting the set is empty.
+    assert "999.999.999.999" not in get_all_ip("bad: 999.999.999.999 here")
+
+
+def test_get_all_ip_rejects_random_hex_garbage():
+    # "dead.beef.cafe" looks IP-shaped (hex chars + dots) but is not an IP;
+    # the v6 path must reject it via stdlib validation, not match it.
+    found = get_all_ip("dead.beef.cafe and feed:face::dead in text")
+    assert "dead.beef.cafe" not in found
+    # but a syntactically valid v6 in the same string IS extracted
+    assert "feed:face::dead" in found
+
+
+def test_get_all_ip_canonicalises_ipv6_for_set_dedup():
+    # Two textual forms of the same v6 address must collapse to one
+    # element in the set (canonical form contract).
+    page = "leak1: 2001:DB8::1 and leak2: 2001:0db8:0000:0000:0000:0000:0000:0001"
+    found = get_all_ip(page)
+    v6_entries = {ip for ip in found if ":" in ip}
+    assert v6_entries == {"2001:db8::1"}
+
+
+def test_get_all_ip_mixed_prose():
+    page = (
+        "Headers: X-Real-IP: 203.0.113.7\n"
+        "X-Forwarded-For: 198.51.100.10, 2001:db8::42\n"
+        "Random text 192.0.2.50:443 trailing"
+    )
+    found = get_all_ip(page)
+    assert {"203.0.113.7", "198.51.100.10", "192.0.2.50", "2001:db8::42"} <= found
+
+
+def test_get_all_ip_empty_page():
+    assert get_all_ip("") == set()
+    assert get_all_ip("no IPs in this prose at all") == set()
+
+
+def test_canonicalize_ip_ipv4_identity():
+    assert canonicalize_ip("127.0.0.1") == "127.0.0.1"
+    assert canonicalize_ip("203.0.113.7") == "203.0.113.7"
+
+
+def test_canonicalize_ip_ipv6_lowercase_compressed():
+    # RFC 5952: lowercase, leading zeros stripped, longest zero-run as ::
+    assert canonicalize_ip("2001:DB8::1") == "2001:db8::1"
+    assert canonicalize_ip("2001:0db8:0000:0000:0000:0000:0000:0001") == "2001:db8::1"
+
+
+def test_canonicalize_ip_ipv6_zone_id_preserved():
+    assert canonicalize_ip("fe80::1%eth0") == "fe80::1%eth0"
+
+
+def test_canonicalize_ip_invalid_returns_none():
+    assert canonicalize_ip("not-an-ip") is None
+    assert canonicalize_ip("999.999.999.999") is None
+    assert canonicalize_ip("") is None
+
+
+def test_find_proxy_pairs_ipv4_baseline():
+    """Drop-in equivalent for the legacy IPPortPatternGlobal usage."""
+    from proxybroker.utils import find_proxy_pairs
+
+    text = "192.0.2.1:8080 trailer 198.51.100.5 9999 mid 203.0.113.10:3128"
+    pairs = find_proxy_pairs(text)
+    assert ("192.0.2.1", "8080") in pairs
+    assert ("203.0.113.10", "3128") in pairs
+
+
+def test_find_proxy_pairs_ipv6_bracketed():
+    """RFC 3986 [v6]:port form must be extracted, with the v6 part
+    canonicalized (lowercase, compressed) so downstream comparison
+    works regardless of the source feed's encoding choice."""
+    from proxybroker.utils import find_proxy_pairs
+
+    text = "Try [2001:DB8::1]:8080 and [fe80::abcd]:1080 for SOCKS"
+    pairs = find_proxy_pairs(text)
+    assert ("2001:db8::1", "8080") in pairs
+    assert ("fe80::abcd", "1080") in pairs
+
+
+def test_find_proxy_pairs_skips_invalid_brackets():
+    """Bracketed garbage that's not a valid v6 must NOT pollute the
+    results."""
+    from proxybroker.utils import find_proxy_pairs
+
+    text = "[zzz::nope]:8080 and [2001:db8::cafe]:443"
+    pairs = find_proxy_pairs(text)
+    assert ("2001:db8::cafe", "443") in pairs
+    assert all(host != "zzz::nope" for host, _ in pairs)
+
+
+def test_find_proxy_pairs_mixed_v4_v6():
+    """One feed with both v4 and v6 entries -> both extracted."""
+    from proxybroker.utils import find_proxy_pairs
+
+    text = "192.0.2.1:8080\n[2001:db8::1]:9090\n198.51.100.5:443\n[fe80::1]:1080"
+    pairs = find_proxy_pairs(text)
+    assert {("192.0.2.1", "8080"), ("198.51.100.5", "443")} <= set(pairs)
+    assert {("2001:db8::1", "9090"), ("fe80::1", "1080")} <= set(pairs)
 
 
 def test_get_status_code():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -161,6 +161,28 @@ def test_find_proxy_pairs_mixed_v4_v6():
     assert {("2001:db8::1", "9090"), ("fe80::1", "1080")} <= set(pairs)
 
 
+def test_find_proxy_pairs_ipv6_with_zone_id():
+    """RFC 6874 zone IDs in bracketed v6 proxies must be accepted.
+
+    Without this, link-local proxies (fe80::1%eth0) silently never
+    parse, even though canonicalize_ip and Resolver.host_is_ip both
+    accept the form.
+    """
+    from proxybroker.utils import find_proxy_pairs
+
+    pairs = find_proxy_pairs("Try [fe80::1%eth0]:8080 for SOCKS")
+    assert ("fe80::1%eth0", "8080") in pairs
+
+
+def test_get_all_ip_strips_trailing_punctuation():
+    """A v6 literal at the end of a sentence (e.g., `Real IP: ::1.`)
+    should still parse - the tokenizer greedily includes trailing dots
+    but they must not break canonicalize_ip validation.
+    """
+    found = get_all_ip("Server says: 2001:db8::1. Cool!")
+    assert "2001:db8::1" in found
+
+
 def test_get_status_code():
     assert get_status_code("HTTP/1.1 200 OK\r\n") == 200
     assert get_status_code("<html>123</html>\r\n") == 400

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,3 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1,3 +1,0 @@
-version = 1
-revision = 3
-requires-python = ">=3.12"


### PR DESCRIPTION
## Summary

Closes #201. Make IPv6 a **first-class citizen alongside IPv4** across detection, validation, anonymity comparison, SOCKS5 proxying, and `[v6]:port` provider parsing — replacing the prior situation of broken/half-wired IPv6 stubs scattered across the codebase.

This expands #201's original scope (refactor `IPv6Pattern` regex) into the full IPv6 epic, per the maintainer review: *"if we are working on IPv6, maybe just make it right. And we can't leave a half-fixed IPv6 there."*

## Why

- **IPv6 reach is real** — Google IPv6 stats show ~45-50% worldwide adoption; mobile networks especially are increasingly IPv6-first.
- **Current state was misleading** — `Resolver.host_is_ip()` is IPv4-only with `# TODO: add IPv6 support`; users on IPv6-only networks failed at startup. The 700-char `IPv6Pattern` regex (with `# nosemgrep`) used many capture groups so `re.findall` returned tuples, not strings — IPv6 anonymity detection has *never* worked.
- **Prior incremental attempt failed** — commit `c1b60b0` (July 2025) tried to add v6 support to `host_is_ip`, shipped real bugs (`::ffff:192.0.2.1` rejected because it contains both `.` and `:`), and never made it to master. That branch is the cautionary tale for why partial IPv6 is unsafe.
- **Root-cause fix** — adopt **RFC 5952 canonical form** (`str(ipaddress.ip_address(...))`) as the single in-process IP representation and thread it through every comparison site. IPv4 form is identity, so v4 contracts are preserved.

## Layer summary

| Layer | File(s) | What |
|---|---|---|
| **L1** | `resolver.py` | `host_is_ip` accepts v4+v6 via stdlib `ipaddress`. `get_real_ext_ip` returns canonical form. Adds `https://api64.ipify.org/` to default endpoints so IPv6-only networks work. |
| **L2** | `utils.py` | Delete 700-char `IPv6Pattern` + `# nosemgrep`. New narrow `_IPV6_CANDIDATE_PATTERN` (provably ReDoS-free) feeds `ipaddress.ip_address` for validation. Public `canonicalize_ip(s) -> str ⎮ None` helper. `get_all_ip` returns canonical form so equivalent encodings collapse. |
| **L3** | `judge.py`, `checker.py` | Canonicalise both sides of IP visibility checks. Substring `real_ext_ip in page` swapped for canonical-form set membership. |
| **L4** | `negotiators.py` | `Socks5Ngtr` emits `ATYP=0x04` + 16-byte for IPv6, `ATYP=0x01` + 4-byte for IPv4 (regression-tested). SOCKS4 stays v4-only by spec. |
| **L6** | `utils.py`, `providers.py`, `api.py` | `IPv6BracketedPortPattern` + `find_proxy_pairs(text)` helper. Wired into `Provider._find_proxies` and `Broker._load`. |
| **L7** | `proxy.py` | `Proxy(host=v6)` works end-to-end. New `_format_host_port` helper brackets v6 per RFC 3986 in `as_text`, `__repr__`, and `Proxy.log`. |

## Out of scope (NOT half-fixes; orthogonal feature concerns)

- IPv6-only judges in defaults — existing httpbin et al already have AAAA records and aiohttp does Happy Eyeballs (RFC 8305).
- Live IPv6 integration tests in CI — runner v6 connectivity not guaranteed; all tests use mocks/local addresses.
- GeoLite2 v6 ranges — blocked by #200; bundled DB has limited v6 coverage. Documented as known limitation.

## Verification

- **pytest:** 239 pass (+32 new IPv6 tests). The 3 pre-existing `test_resolver` `event_loop` fixture errors are unrelated and were present on master before this branch.
- **Ruff:** clean (`ruff check --fix`, `ruff format`).
- **Pre-commit hooks:** all green.
- **Opsera security scan:** 0 NEW critical/high findings. 44 existing findings are all in pre-existing dependencies, scan-output artifacts in `tmp/`, and Claude config — none introduced by this PR.
- **Docker:** built `proxybroker2-ipv6-smoke:latest` and:
  - Smoke-tested all 5 capability layers inside the container (host_is_ip, canonicalize_ip, get_all_ip, find_proxy_pairs, Proxy v6).
  - Ran `find --types HTTP --limit 2` for IPv4 regression — returned 2 working real HTTP proxies (US), confirming no v4 regression.

## Test plan

- [ ] CI green (pytest matrix Py 3.10–3.14, ruff)
- [ ] Snyk / SonarCloud / Fossabot / CodeRabbit — no new high/critical
- [ ] Docker workflow builds successfully on PR
- [ ] Manual: `docker run --rm bluet/proxybroker2:<test-tag> find --types HTTP --limit 3` — verifies v4 path
- [ ] Manual: `docker run --rm bluet/proxybroker2:<test-tag> python -c "from proxybroker import Proxy; print(Proxy('2001:db8::1', 8080))"` — verifies v6 construct + repr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded IPv6 support: concurrent A/AAAA resolution (Happy Eyeballs), canonical RFC‑5952 IPv6 formatting, SOCKS5 IPv6 wire handling, bracketed [v6]:port parsing/formatting, and explicit SOCKS4 rejection for IPv6.

* **Bug Fixes**
  * More reliable anonymity detection and IP comparisons via canonicalized IP handling; improved proxy extraction including bracketed IPv6.

* **Documentation**
  * Added repo-level IPv6 guidance and updated changelog.

* **Tests**
  * Extensive IPv6-focused tests across resolution, negotiation, parsing, formatting, and anonymity checks.

* **Chores**
  * Updated local ignore and scan config entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->