### PR TITLE
docs: fix broken Star History chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,10 +661,10 @@ This project follows the [all-contributors](https://github.com/all-contributors/
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=bluet%2Fproxybroker2&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#bluet/proxybroker2&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=bluet/proxybroker2&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=bluet/proxybroker2&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=bluet/proxybroker2&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=bluet/proxybroker2&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=bluet/proxybroker2&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=bluet/proxybroker2&type=date&legend=top-left" />
  </picture>
 </a>


### PR DESCRIPTION
The Star History chart in the README is currently broken because the GitHub stargazer API limits data access. This change points the chart at star-history.dera.page, an alternative that uses a different data source requiring no API token, so the chart renders correctly again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Star History embeds to use the new `star-history.dera.page` URLs.
  * Replaced outdated Star History and API endpoint references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->